### PR TITLE
Bugfix/pvp logging fix

### DIFF
--- a/db-builder/README.md
+++ b/db-builder/README.md
@@ -1,0 +1,123 @@
+# Star Citizen Ship Database Builder
+
+This tool builds a comprehensive ship database for Star Citizen by fetching data from the Star Citizen Wiki API using a two-phase approach.
+
+## Two-Phase System
+
+### Phase 1: Collect Ship Links
+
+- Fetches all ships from the Star Citizen Wiki API
+- Collects ship names, UUIDs, and API links
+- Handles pagination to get all 241+ ships
+- Outputs to `working/ship-links.json`
+
+### Phase 2: Fetch Detailed Data
+
+- Reads ship links from Phase 1 output
+- Fetches detailed ship data with components, weapons, and stats
+- Transforms API data to match custom JSON format
+- Outputs complete database to `working/temp-ships.json`
+
+## Usage
+
+Run these commands from the root directory:
+
+### Run Phase 1 Only (Collect Links)
+
+```bash
+npm run phase1
+```
+
+### Run Phase 2 Only (Fetch Details)
+
+```bash
+npm run phase2
+```
+
+### Run Both Phases (Complete Build)
+
+```bash
+npm run build-ships
+```
+
+## Output Files
+
+- **`working/ship-links.json`** - Phase 1 output with all ship links
+- **`working/temp-ships.json`** - Phase 2 output with complete ship database
+- **`Ships.json`** - Final database (copy from temp-ships.json when ready)
+
+## Data Structure
+
+Each ship contains comprehensive data:
+
+### Stats
+
+- **ship-size**: small, medium, large, capital, snub, vehicle
+- **purchase-price**: In-game purchase price (null if not purchasable)
+- **crew**: Minimum crew requirement
+- **cargo**: Cargo capacity in SCU
+- **stowage**: Vehicle inventory capacity
+- **speed**: max, scm, roll, pitch, yaw
+- **emission**: ir, em_idle, em_max
+- **fuel**: quantum, hydro
+
+### Weapons
+
+- **Pilot Controlled**: Direct weapon mounts
+- **Player Controlled Turret**: Manual turrets
+- **PDC Auto Turret**: Point defense turrets
+
+### Missiles
+
+- **size**: Missile size
+- **count**: Number of missiles
+- **missle-class**: Missile class name
+
+### Defensive
+
+- **decoy**: Decoy launchers with count
+- **noise**: Noise launchers with count
+
+### Components
+
+- **shields**: Shield generator classes
+- **power-plants**: Power plant classes
+- **coolers**: Cooler classes
+- **quantum-drives**: Quantum drive classes
+
+### Additional Data
+
+- **health**: Part-by-part health values (lowercase keys)
+- **flight-ready**: Boolean flight status
+- **shops**: Purchase locations
+
+## API Endpoints Used
+
+- **Ship List**: `https://api.star-citizen.wiki/api/v3/vehicles?page={page}`
+- **Ship Details**: `https://api.star-citizen.wiki/api/v3/vehicles/{uuid}?locale=en_EN&include=ports,shops`
+
+## Features
+
+- **Rate Limiting**: 500ms delay between API requests
+- **Error Handling**: Graceful handling of 404 errors and missing data
+- **Data Validation**: Checks for valid relations before processing
+- **Comprehensive Coverage**: Processes 190+ ships with detailed data
+- **Modular Design**: Separate phases for better maintainability
+
+## Project Structure
+
+```
+├── ship-db-builder/
+│   ├── phase-1-build-structure.js    # Phase 1: Collect links
+│   └── phase-2-fetch-details.js      # Phase 2: Fetch details
+├── working/
+│   ├── ship-links.json               # Phase 1 output
+│   └── temp-ships.json               # Phase 2 output
+├── Ships.json                        # Final database
+├── SampleData.json                   # Reference structure
+└── package.json                      # Scripts and dependencies
+```
+
+## Next Steps
+
+The database is ready for Firestore integration to upload to your cloud database.

--- a/db-builder/package-lock.json
+++ b/db-builder/package-lock.json
@@ -1,0 +1,53 @@
+{
+  "name": "statizen-db-api",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "statizen-db-api",
+      "version": "1.0.0",
+      "dependencies": {
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/db-builder/package.json
+++ b/db-builder/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "statizen-db-api",
+  "version": "1.0.0",
+  "description": "Star Citizen ship database builder",
+  "main": "ship-db-builder.js",
+  "scripts": {
+    "phase1": "node ship-db-builder/phase-1-build-structure.js",
+    "phase2": "node ship-db-builder/phase-2-fetch-details.js",
+    "build-ships": "npm run phase1 && npm run phase2"
+  },
+  "dependencies": {
+    "node-fetch": "^2.6.7"
+  },
+  "type": "module"
+}

--- a/db-builder/ship-db-builder/phase-1-build-structure.js
+++ b/db-builder/ship-db-builder/phase-1-build-structure.js
@@ -1,0 +1,125 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+class Phase1LinkCollector {
+  constructor() {
+    this.apiBaseUrl = 'https://api.star-citizen.wiki/api/v3/vehicles';
+  }
+
+  /**
+   * Main function to collect ship links
+   */
+  async buildStructure() {
+    try {
+      console.log('🚀 Starting Phase 1: Collecting Ship Links...');
+
+      // Step 1: Get list of all ships from the API
+      const shipList = await this.fetchShipList();
+      console.log(`📋 Found ${shipList.length} ships to process`);
+
+      // Step 2: Write the ship links to a temporary JSON file
+      await this.writeShipLinks(shipList);
+
+      console.log('✅ Phase 1 completed successfully!');
+      console.log(`📊 Collected links for ${shipList.length} ships`);
+    } catch (error) {
+      console.error('❌ Error in Phase 1:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Fetch the list of all ships from Star Citizen wiki API
+   */
+  async fetchShipList() {
+    try {
+      console.log('🔍 Fetching ship list from Star Citizen wiki...');
+
+      let allShips = [];
+      let currentPage = 1;
+      let hasMorePages = true;
+
+      while (hasMorePages) {
+        console.log(`📄 Fetching page ${currentPage}...`);
+
+        const response = await fetch(`${this.apiBaseUrl}?page=${currentPage}`);
+
+        if (!response.ok) {
+          throw new Error(`API request failed: ${response.status}`);
+        }
+
+        const data = await response.json();
+
+        // Extract ships from current page
+        const pageShips =
+          data.data?.map((ship) => ({
+            name: ship.name,
+            uuid: ship.uuid,
+            link: ship.link,
+          })) || [];
+
+        allShips = allShips.concat(pageShips);
+
+        // Check if there are more pages
+        hasMorePages = data.links?.next !== null;
+        currentPage++;
+
+        // Small delay to be respectful to the API
+        await this.delay(500);
+      }
+
+      console.log(`📊 Retrieved ${allShips.length} ships from API across ${currentPage - 1} pages`);
+      return allShips;
+    } catch (error) {
+      console.error('❌ Error fetching ship list:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Write ship links to temporary JSON file
+   */
+  async writeShipLinks(shipList) {
+    try {
+      console.log('💾 Writing ship links to working/ship-links.json...');
+
+      const linksData = {
+        version: '1.0.5',
+        totalShips: shipList.length,
+        ships: shipList,
+      };
+
+      const filePath = path.join(__dirname, '..', 'working', 'ship-links.json');
+      const jsonData = JSON.stringify(linksData, null, 2);
+
+      await fs.writeFile(filePath, jsonData, 'utf8');
+
+      console.log(`✅ Ship links written successfully! ${shipList.length} ship links saved.`);
+    } catch (error) {
+      console.error('❌ Error writing ship links:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Utility function to add delays
+   */
+  delay(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+// Main execution
+async function main() {
+  const collector = new Phase1LinkCollector();
+  await collector.buildStructure();
+}
+
+// Run the script
+main().catch(console.error);
+
+export default Phase1LinkCollector;

--- a/db-builder/ship-db-builder/phase-2-fetch-details.js
+++ b/db-builder/ship-db-builder/phase-2-fetch-details.js
@@ -1,0 +1,391 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+class Phase2DetailFetcher {
+  constructor() {
+    this.shipsData = {
+      version: '1.0.5',
+      ships: {},
+    };
+  }
+
+  /**
+   * Main function to fetch detailed ship data
+   */
+  async fetchDetails() {
+    try {
+      console.log('🚀 Starting Phase 2: Fetching Ship Details...');
+
+      // Step 1: Load ship links from working directory
+      const shipLinks = await this.loadShipLinks();
+      console.log(`📋 Found ${shipLinks.length} ships to process`);
+
+      // Step 2: Fetch detailed data for each ship
+      await this.fetchShipDetails(shipLinks);
+
+      // Step 3: Write the detailed data to temp-ships.json
+      await this.writeTempShips();
+
+      console.log('✅ Phase 2 completed successfully!');
+      console.log(`📊 Fetched details for ${Object.keys(this.shipsData.ships).length} ships`);
+    } catch (error) {
+      console.error('❌ Error in Phase 2:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Load ship links from working directory
+   */
+  async loadShipLinks() {
+    try {
+      console.log('📖 Loading ship links from working/ship-links.json...');
+
+      const filePath = path.join(__dirname, '..', 'working', 'ship-links.json');
+      const fileContent = await fs.readFile(filePath, 'utf8');
+      const linksData = JSON.parse(fileContent);
+
+      console.log(`📊 Loaded ${linksData.ships.length} ship links`);
+      return linksData.ships;
+    } catch (error) {
+      console.error('❌ Error loading ship links:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Fetch detailed data for all ships
+   */
+  async fetchShipDetails(shipLinks) {
+    console.log(`🔄 Fetching detailed data for all ${shipLinks.length} ships...`);
+
+    for (let i = 0; i < shipLinks.length; i++) {
+      const ship = shipLinks[i];
+      console.log(`🛸 Processing ship ${i + 1}/${shipLinks.length}: ${ship.name}`);
+
+      try {
+        // Fetch detailed ship data
+        const detailedData = await this.fetchShipDetail(ship.link);
+
+        // Extract and transform the data
+        const transformedData = this.transformShipData(detailedData, ship.name);
+
+        // Add to our ships database using class_name as key
+        if (detailedData.data && detailedData.data.class_name) {
+          this.shipsData.ships[detailedData.data.class_name] = transformedData;
+          console.log(`✅ Successfully processed: ${ship.name} (${detailedData.data.class_name})`);
+        } else {
+          console.log(`⚠️  No class_name found for: ${ship.name}`);
+        }
+      } catch (error) {
+        // Only log 404 errors once to avoid spam
+        if (error.message.includes('404')) {
+          console.log(`⚠️  Ship not found: ${ship.name} (skipping)`);
+        } else {
+          console.error(`❌ Error processing ship ${ship.name}:`, error.message);
+        }
+      }
+
+      // 500ms delay between requests to avoid rate limits
+      if (i < shipLinks.length - 1) {
+        await this.delay(500);
+      }
+    }
+  }
+
+  /**
+   * Fetch detailed ship information from a single link
+   */
+  async fetchShipDetail(link) {
+    try {
+      // Convert v2 to v3 API and add locale and include parameters
+      const v3Link = link.replace('/api/v2/vehicles/', '/api/v3/vehicles/');
+      const enhancedLink = `${v3Link}?locale=en_EN&include=ports,shops`;
+      const response = await fetch(enhancedLink);
+
+      if (!response.ok) {
+        throw new Error(`API request failed: ${response.status}`);
+      }
+
+      const data = await response.json();
+      return data;
+    } catch (error) {
+      console.error(`❌ Error fetching details from ${link}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Transform API data to match our JSON format
+   */
+  transformShipData(apiResponse, shipName) {
+    const apiData = apiResponse.data;
+    const meta = apiResponse.meta;
+
+    // Check if ports/hardpoints and shops are available
+    const hasPorts = meta.valid_relations && meta.valid_relations.includes('ports');
+    const hasHardpoints = meta.valid_relations && meta.valid_relations.includes('hardpoints');
+    const hasShops = meta.valid_relations && meta.valid_relations.includes('shops');
+
+    // Extract health data from parts - convert to lowercase keys
+    const healthData = {};
+    if (apiData.parts && apiData.parts.length > 0) {
+      const extractHealthFromParts = (parts) => {
+        parts.forEach((part) => {
+          if (part.damage_max > 0) {
+            const key = part.display_name.toLowerCase();
+            healthData[key] = part.damage_max;
+          }
+          if (part.children && part.children.length > 0) {
+            extractHealthFromParts(part.children);
+          }
+        });
+      };
+      extractHealthFromParts(apiData.parts);
+    }
+
+    // Extract components and weapons from ports if available
+    let weapons = [];
+    let components = {
+      shields: [],
+      'power-plants': [],
+      coolers: [],
+      'quantum-drives': [],
+    };
+    let missles = [];
+    let defensive = [];
+    let flightStatus = true;
+    let purchasePrice = null;
+    let maxSpeed = 0;
+    let scmSpeed = 0;
+    let maxPitch = 0;
+    let maxYaw = 0;
+    let maxRoll = 0;
+    let shops = [];
+
+    // Use hardpoints if ports are not available
+    const portsData = hasPorts ? apiData.ports : hasHardpoints ? apiData.hardpoints : null;
+
+    if (portsData) {
+      // Process ports/hardpoints for components and weapons
+      portsData.forEach((port) => {
+        // Check if this port itself has weapons or missiles in its ports array
+        if (port.ports) {
+          port.ports.forEach((weaponPort) => {
+            if (weaponPort.equipped_item && weaponPort.equipped_item.type === 'WeaponGun') {
+              const weapon = weaponPort.equipped_item;
+
+              // Determine weapon type based on the parent port's equipped_item sub_type
+              let weaponType = 'Pilot Controlled';
+              if (port.equipped_item && port.equipped_item.sub_type === 'PDCTurret') {
+                weaponType = 'PDC Auto Turret';
+              } else if (port.equipped_item && port.equipped_item.sub_type === 'GunTurret') {
+                weaponType = 'Pilot Controlled';
+              }
+
+              weapons.push({
+                type: weaponType,
+                class: weapon.class_name,
+              });
+            } else if (weaponPort.equipped_item && weaponPort.equipped_item.type === 'Missile') {
+              const missile = weaponPort.equipped_item;
+
+              // Check if we already have this missile type
+              const existingMissile = missles.find((m) => m['missle-class'] === missile.class_name);
+              if (existingMissile) {
+                existingMissile.count += 1;
+              } else {
+                missles.push({
+                  size: missile.size,
+                  count: 1,
+                  'missle-class': missile.class_name,
+                });
+              }
+            }
+          });
+        }
+
+        // Check if this port itself is a PDC turret (has no equipped weapon but is a PDC turret)
+        if (port.equipped_item && port.equipped_item.type === 'Turret' && port.equipped_item.sub_type === 'PDCTurret') {
+          weapons.push({
+            type: 'PDC Auto Turret',
+            class: port.equipped_item.class_name,
+          });
+        }
+
+        if (port.equipped_item) {
+          const item = port.equipped_item;
+          const itemType = item.type;
+          const itemSubType = item.sub_type;
+
+          // Weapons - get the actual weapon class from nested ports
+          if (itemType === 'Turret' && item.ports) {
+            item.ports.forEach((weaponPort) => {
+              if (weaponPort.equipped_item && weaponPort.equipped_item.type === 'WeaponGun') {
+                const weapon = weaponPort.equipped_item;
+                weapons.push({
+                  type: 'Pilot Controlled',
+                  class: weapon.class_name,
+                });
+              }
+            });
+          } else if (itemType === 'TurretBase') {
+            weapons.push({
+              type: 'Player Controlled Turret',
+              class: item.class_name,
+            });
+          } else if (itemType === 'turret' && itemSubType === 'PDCTurret') {
+            weapons.push({
+              type: 'PDC Auto Turret',
+              class: item.class_name,
+            });
+          }
+
+          // Components - just get the class name
+          if (itemType === 'Shield') {
+            components.shields.push({
+              class: item.class_name,
+            });
+          } else if (itemType === 'PowerPlant') {
+            components['power-plants'].push({
+              class: item.class_name,
+            });
+          } else if (itemType === 'Cooler') {
+            components.coolers.push({
+              class: item.class_name,
+            });
+          } else if (itemType === 'QuantumDrive') {
+            components['quantum-drives'].push({
+              class: item.class_name,
+            });
+          }
+
+          // Missiles - get size, count, and size-class
+          if (itemType === 'MissileLauncher' && item.ports) {
+            const missileCount = item.ports.filter((port) => port.equipped_item && port.equipped_item.type === 'Missile').length;
+            if (missileCount > 0) {
+              const firstMissile = item.ports.find((port) => port.equipped_item && port.equipped_item.type === 'Missile').equipped_item;
+              missles.push({
+                size: firstMissile.size,
+                count: missileCount,
+                'size-class': firstMissile.size,
+              });
+            }
+          }
+
+          // Defensive (Decoy/Noise)
+          if (itemType === 'WeaponDefensive') {
+            if (item.class_name && item.class_name.includes('decoy')) {
+              defensive.push({
+                type: 'decoy',
+                count: item.counter_measure?.capacity || 0,
+                name: item.name,
+              });
+            } else if (item.class_name && item.class_name.includes('noise')) {
+              defensive.push({
+                type: 'noise',
+                count: item.counter_measure?.capacity || 0,
+                name: item.name,
+              });
+            }
+          }
+
+          // Flight controller data
+          if (itemType === 'FlightController' && item.flight_controller) {
+            maxSpeed = item.flight_controller.max_speed || 0;
+            scmSpeed = item.flight_controller.scm_speed || 0;
+            maxPitch = item.flight_controller.pitch || 0;
+            maxYaw = item.flight_controller.yaw || 0;
+            maxRoll = item.flight_controller.roll || 0;
+          }
+        }
+      });
+    }
+
+    // Extract shop data if available
+    if (hasShops && apiData.shops && apiData.shops.length > 0) {
+      purchasePrice = apiData.shops[0].items?.[0]?.base_price || null;
+      shops = apiData.shops.map((shop) => shop.name_raw);
+    }
+
+    // Check flight status
+    if (apiData.production_status && apiData.production_status.en_EN !== 'flight-ready') {
+      flightStatus = false;
+    }
+
+    return {
+      name: shipName,
+      stats: {
+        'ship-size': apiData.size?.en_EN || apiData.size || '',
+        'purchase-price': purchasePrice,
+        crew: apiData.crew?.min || 1,
+        cargo: apiData.cargo_capacity || 0,
+        stowage: Math.round((apiData.vehicle_inventory || 0) * 1000000),
+        speed: {
+          max: maxSpeed,
+          scm: scmSpeed,
+          roll: maxRoll,
+          pitch: maxPitch,
+          yaw: maxYaw,
+        },
+        emission: {
+          ir: apiData.emission?.ir || 0,
+          em_idle: apiData.emission?.em_idle || 0,
+          em_max: apiData.emission?.em_max || 0,
+        },
+        fuel: {
+          quantum: apiData.quantum?.quantum_fuel_capacity || 0,
+          hydro: apiData.fuel?.capacity || 0,
+        },
+      },
+      weapons,
+      missles,
+      defensive,
+      health: healthData,
+      components,
+      'flight-ready': flightStatus,
+      shops,
+    };
+  }
+
+  /**
+   * Write the detailed data to temp-ships.json
+   */
+  async writeTempShips() {
+    try {
+      console.log('💾 Writing detailed ship data to working/temp-ships.json...');
+
+      const filePath = path.join(__dirname, '..', 'working', 'temp-ships.json');
+      const jsonData = JSON.stringify(this.shipsData, null, 2);
+
+      await fs.writeFile(filePath, jsonData, 'utf8');
+
+      console.log(`✅ Detailed ship data written successfully! ${Object.keys(this.shipsData.ships).length} ships processed.`);
+    } catch (error) {
+      console.error('❌ Error writing temp ships data:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Utility function to add delays
+   */
+  delay(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+// Main execution
+async function main() {
+  const fetcher = new Phase2DetailFetcher();
+  await fetcher.fetchDetails();
+}
+
+// Run the script
+main().catch(console.error);
+
+export default Phase2DetailFetcher;

--- a/db-builder/working/ship-links.json
+++ b/db-builder/working/ship-links.json
@@ -1,0 +1,1216 @@
+{
+  "version": "1.0.5",
+  "totalShips": 241,
+  "ships": [
+    {
+      "name": "100i",
+      "uuid": "6135a874-4cb1-4f49-9f29-5781e5991f2b",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/6135a874-4cb1-4f49-9f29-5781e5991f2b"
+    },
+    {
+      "name": "125a",
+      "uuid": "e7eeba8d-b108-48a1-a332-d9edbab2b9c1",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/e7eeba8d-b108-48a1-a332-d9edbab2b9c1"
+    },
+    {
+      "name": "135c",
+      "uuid": "2f231daa-95e5-4cb2-a32e-4db8f29a30d6",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/2f231daa-95e5-4cb2-a32e-4db8f29a30d6"
+    },
+    {
+      "name": "300i",
+      "uuid": "ce937681-caa2-4cfa-ab80-f5bf2a5b9a6c",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/ce937681-caa2-4cfa-ab80-f5bf2a5b9a6c"
+    },
+    {
+      "name": "315p",
+      "uuid": "dc537d66-2abb-43aa-9d37-4e963fc6e9e2",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/dc537d66-2abb-43aa-9d37-4e963fc6e9e2"
+    },
+    {
+      "name": "325a",
+      "uuid": "039a2768-1aff-4969-b2a4-ed8aeb21dae1",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/039a2768-1aff-4969-b2a4-ed8aeb21dae1"
+    },
+    {
+      "name": "350r",
+      "uuid": "316c6601-b405-4a3a-abac-394c655718f8",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/316c6601-b405-4a3a-abac-394c655718f8"
+    },
+    {
+      "name": "400i",
+      "uuid": "718f4435-628b-4436-bb80-bf9cfef9a945",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/718f4435-628b-4436-bb80-bf9cfef9a945"
+    },
+    {
+      "name": "600i Explorer",
+      "uuid": "f8ac4c26-8f4d-4cb3-9be2-7d867a95a877",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/f8ac4c26-8f4d-4cb3-9be2-7d867a95a877"
+    },
+    {
+      "name": "600i Touring",
+      "uuid": "11b660a2-c77c-490b-9e85-ee70400c5cf8",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/11b660a2-c77c-490b-9e85-ee70400c5cf8"
+    },
+    {
+      "name": "85X",
+      "uuid": "9dc9c257-c413-416a-ab9b-06fbadf18d1e",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/9dc9c257-c413-416a-ab9b-06fbadf18d1e"
+    },
+    {
+      "name": "890 Jump",
+      "uuid": "50ddaf5e-a8e3-42fe-a1d3-7267f39b39b0",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/50ddaf5e-a8e3-42fe-a1d3-7267f39b39b0"
+    },
+    {
+      "name": "A1 Spirit",
+      "uuid": "c0b86c69-55ac-4af3-a722-d46282813e91",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/c0b86c69-55ac-4af3-a722-d46282813e91"
+    },
+    {
+      "name": "A2 Hercules",
+      "uuid": "3bee9f2d-4494-4560-b9f8-463bc90695cb",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/3bee9f2d-4494-4560-b9f8-463bc90695cb"
+    },
+    {
+      "name": "Anvil Ballista Dunestalker",
+      "uuid": "50f551e3-3435-4cbe-9ecf-8712855a8e27",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/50f551e3-3435-4cbe-9ecf-8712855a8e27"
+    },
+    {
+      "name": "Anvil Ballista Snowblind",
+      "uuid": "aaeb976b-7a79-4a9c-91ee-07ed05d4a399",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/aaeb976b-7a79-4a9c-91ee-07ed05d4a399"
+    },
+    {
+      "name": "Apollo Medivac",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Apollo+Medivac"
+    },
+    {
+      "name": "Apollo Triage",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Apollo+Triage"
+    },
+    {
+      "name": "Ares Inferno",
+      "uuid": "04571d49-0680-4b84-bdb1-dbebeb22c898",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/04571d49-0680-4b84-bdb1-dbebeb22c898"
+    },
+    {
+      "name": "Ares Ion",
+      "uuid": "30aab266-9131-4a07-808b-61c868cb404f",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/30aab266-9131-4a07-808b-61c868cb404f"
+    },
+    {
+      "name": "Argo Mole Carbon Edition",
+      "uuid": "9c49ab88-43a0-4ea7-b159-1f1dd44b49b2",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/9c49ab88-43a0-4ea7-b159-1f1dd44b49b2"
+    },
+    {
+      "name": "Argo Mole Talus Edition",
+      "uuid": "31eaaac4-b1ee-4430-a01c-b4ef0470715d",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/31eaaac4-b1ee-4430-a01c-b4ef0470715d"
+    },
+    {
+      "name": "Arrastra",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Arrastra"
+    },
+    {
+      "name": "Arrow",
+      "uuid": "eaeb562d-d4ac-43bd-a843-e8a6d69fad82",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/eaeb562d-d4ac-43bd-a843-e8a6d69fad82"
+    },
+    {
+      "name": "Asgard",
+      "uuid": "8ffde65b-ee9b-4a50-b386-3111175736b2",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/8ffde65b-ee9b-4a50-b386-3111175736b2"
+    },
+    {
+      "name": "ATLS",
+      "uuid": "09c9fa95-5b5a-4200-9ff8-3b288df9925b",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/09c9fa95-5b5a-4200-9ff8-3b288df9925b"
+    },
+    {
+      "name": "ATLS GEO",
+      "uuid": "a10bcff6-7985-431f-b0ea-bdb51e6d3f98",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/a10bcff6-7985-431f-b0ea-bdb51e6d3f98"
+    },
+    {
+      "name": "Aurora CL",
+      "uuid": "7cab9bbc-3d67-4ee7-99ef-fe41991f8a3b",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/7cab9bbc-3d67-4ee7-99ef-fe41991f8a3b"
+    },
+    {
+      "name": "Aurora ES",
+      "uuid": "42b72b92-7880-446d-8770-b158e4b0fd10",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/42b72b92-7880-446d-8770-b158e4b0fd10"
+    },
+    {
+      "name": "Aurora LN",
+      "uuid": "984283ce-dd5f-4807-a7b0-f6fbf053716c",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/984283ce-dd5f-4807-a7b0-f6fbf053716c"
+    },
+    {
+      "name": "Aurora LX",
+      "uuid": "bb8e3cdf-7f35-4bdb-bc2d-a15b8b859359",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/bb8e3cdf-7f35-4bdb-bc2d-a15b8b859359"
+    },
+    {
+      "name": "Aurora MR",
+      "uuid": "c596f592-1196-4378-8583-18ff13962b85",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/c596f592-1196-4378-8583-18ff13962b85"
+    },
+    {
+      "name": "Avenger Stalker",
+      "uuid": "97648869-5fa5-42da-b804-4d9314289539",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/97648869-5fa5-42da-b804-4d9314289539"
+    },
+    {
+      "name": "Avenger Titan",
+      "uuid": "0079c5d5-1678-4f8c-85ba-18ca8f642af6",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/0079c5d5-1678-4f8c-85ba-18ca8f642af6"
+    },
+    {
+      "name": "Avenger Titan Renegade",
+      "uuid": "d9bc09ce-4c74-4f72-892e-a833c094f4e6",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/d9bc09ce-4c74-4f72-892e-a833c094f4e6"
+    },
+    {
+      "name": "Avenger Warlock",
+      "uuid": "9474f571-8467-4d83-b1fe-f64103d363f4",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/9474f571-8467-4d83-b1fe-f64103d363f4"
+    },
+    {
+      "name": "Ballista",
+      "uuid": "a04a1503-ac5c-4520-bc22-4b1a1a198eff",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/a04a1503-ac5c-4520-bc22-4b1a1a198eff"
+    },
+    {
+      "name": "Blade",
+      "uuid": "0d4c5000-ffdb-41f5-9de1-d64252dfef21",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/0d4c5000-ffdb-41f5-9de1-d64252dfef21"
+    },
+    {
+      "name": "Buccaneer",
+      "uuid": "efec4d48-77ab-4cba-9add-a3d96c5be8d8",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/efec4d48-77ab-4cba-9add-a3d96c5be8d8"
+    },
+    {
+      "name": "C1 Spirit",
+      "uuid": "9611b8ed-cc96-4b5c-aa1e-baefe7d5bb1c",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/9611b8ed-cc96-4b5c-aa1e-baefe7d5bb1c"
+    },
+    {
+      "name": "C2 Hercules",
+      "uuid": "7533ff77-836c-4bd2-9171-487d9c63863c",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/7533ff77-836c-4bd2-9171-487d9c63863c"
+    },
+    {
+      "name": "C8 Pisces",
+      "uuid": "20d5f617-147a-4530-a753-a7afd1875fd1",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/20d5f617-147a-4530-a753-a7afd1875fd1"
+    },
+    {
+      "name": "C8R Pisces",
+      "uuid": "1bed9058-e284-4c0f-b561-6ba57ab4f99d",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/1bed9058-e284-4c0f-b561-6ba57ab4f99d"
+    },
+    {
+      "name": "C8X Pisces Expedition",
+      "uuid": "831fdcfc-337a-4350-967d-e693d19efeee",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/831fdcfc-337a-4350-967d-e693d19efeee"
+    },
+    {
+      "name": "Carrack",
+      "uuid": "f6d606c9-b324-4efa-814f-15a59047a6a5",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/f6d606c9-b324-4efa-814f-15a59047a6a5"
+    },
+    {
+      "name": "Carrack Expedition",
+      "uuid": "f1b224dd-273e-488f-9dee-fbf73f44f462",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/f1b224dd-273e-488f-9dee-fbf73f44f462"
+    },
+    {
+      "name": "Carrack Expedition w/C8X",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Carrack+Expedition+w%2FC8X"
+    },
+    {
+      "name": "Carrack w/C8X",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Carrack+w%2FC8X"
+    },
+    {
+      "name": "Caterpillar",
+      "uuid": "dc39ca6b-1d76-4db5-9346-356f49954978",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/dc39ca6b-1d76-4db5-9346-356f49954978"
+    },
+    {
+      "name": "Caterpillar Best In Show Edition 2949",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Caterpillar+Best+In+Show+Edition+2949"
+    },
+    {
+      "name": "Caterpillar Pirate Edition",
+      "uuid": "565d8121-50a9-4920-af50-f176caef0431",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/565d8121-50a9-4920-af50-f176caef0431"
+    },
+    {
+      "name": "Centurion",
+      "uuid": "27515ffd-04df-413f-8533-34612d906c7d",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/27515ffd-04df-413f-8533-34612d906c7d"
+    },
+    {
+      "name": "Constellation Andromeda",
+      "uuid": "d95fb013-60d5-43ac-ab2d-daa082f45411",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/d95fb013-60d5-43ac-ab2d-daa082f45411"
+    },
+    {
+      "name": "Constellation Aquila",
+      "uuid": "e7b40f5c-4099-4aa6-b226-b5b08bd68413",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/e7b40f5c-4099-4aa6-b226-b5b08bd68413"
+    },
+    {
+      "name": "Constellation Phoenix",
+      "uuid": "ecadf2b2-a404-4776-9289-04af91538d76",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/ecadf2b2-a404-4776-9289-04af91538d76"
+    },
+    {
+      "name": "Constellation Phoenix Emerald",
+      "uuid": "daf936a1-689f-4edb-980a-96947e2727c4",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/daf936a1-689f-4edb-980a-96947e2727c4"
+    },
+    {
+      "name": "Constellation Taurus",
+      "uuid": "d1c3fa10-b2d9-421e-8301-97dbf4d0c115",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/d1c3fa10-b2d9-421e-8301-97dbf4d0c115"
+    },
+    {
+      "name": "Corsair",
+      "uuid": "e1afb014-fe71-4da9-89ae-c30fcf9c0782",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/e1afb014-fe71-4da9-89ae-c30fcf9c0782"
+    },
+    {
+      "name": "Crucible",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Crucible"
+    },
+    {
+      "name": "CSV-SM",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/CSV-SM"
+    },
+    {
+      "name": "Cutlass Black",
+      "uuid": "b58f7735-9454-4a0a-b724-2bc8d61961d7",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/b58f7735-9454-4a0a-b724-2bc8d61961d7"
+    },
+    {
+      "name": "Cutlass Black Best In Show Edition 2949",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Cutlass+Black+Best+In+Show+Edition+2949"
+    },
+    {
+      "name": "Cutlass Blue",
+      "uuid": "13c3f610-7bbd-4464-bd36-d716de49a125",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/13c3f610-7bbd-4464-bd36-d716de49a125"
+    },
+    {
+      "name": "Cutlass Red",
+      "uuid": "7780e93d-1cc3-43b4-9b32-9923af19775a",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/7780e93d-1cc3-43b4-9b32-9923af19775a"
+    },
+    {
+      "name": "Cutlass Steel",
+      "uuid": "384d7e27-daec-4554-a8e9-6920a10a86c1",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/384d7e27-daec-4554-a8e9-6920a10a86c1"
+    },
+    {
+      "name": "Cutter",
+      "uuid": "3ea9bcd8-1ddd-4714-a537-7b2675e8c2d2",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/3ea9bcd8-1ddd-4714-a537-7b2675e8c2d2"
+    },
+    {
+      "name": "Cutter Rambler",
+      "uuid": "93b13680-9aa6-4c21-b998-e4f8880f7c12",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/93b13680-9aa6-4c21-b998-e4f8880f7c12"
+    },
+    {
+      "name": "Cutter Scout",
+      "uuid": "887cd720-7337-44ae-9708-828ccf808649",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/887cd720-7337-44ae-9708-828ccf808649"
+    },
+    {
+      "name": "Cyclone",
+      "uuid": "8dbb42e4-e127-4153-9694-2845142c3e51",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/8dbb42e4-e127-4153-9694-2845142c3e51"
+    },
+    {
+      "name": "Cyclone AA",
+      "uuid": "0194943d-1164-4b5f-a85e-79ebc0ebe621",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/0194943d-1164-4b5f-a85e-79ebc0ebe621"
+    },
+    {
+      "name": "Cyclone MT",
+      "uuid": "bda93768-c01f-40b4-a92e-f31876cd33d0",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/bda93768-c01f-40b4-a92e-f31876cd33d0"
+    },
+    {
+      "name": "Cyclone RC",
+      "uuid": "064951d7-3dd0-49c2-8b88-d2d7f809633e",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/064951d7-3dd0-49c2-8b88-d2d7f809633e"
+    },
+    {
+      "name": "Cyclone RN",
+      "uuid": "b389839d-fdf9-4c41-850a-4e7461250304",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/b389839d-fdf9-4c41-850a-4e7461250304"
+    },
+    {
+      "name": "Cyclone TR",
+      "uuid": "f80914cf-643e-4b7e-b715-eaf9aa572954",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/f80914cf-643e-4b7e-b715-eaf9aa572954"
+    },
+    {
+      "name": "Defender",
+      "uuid": "081236f5-9549-4a60-9123-6ae21f0cd261",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/081236f5-9549-4a60-9123-6ae21f0cd261"
+    },
+    {
+      "name": "Dragonfly Black",
+      "uuid": "37659ff0-a803-4a4f-97ff-ad59822061ed",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/37659ff0-a803-4a4f-97ff-ad59822061ed"
+    },
+    {
+      "name": "Dragonfly Yellowjacket",
+      "uuid": "533b9b62-33eb-4b34-95eb-d43fe3e020ff",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/533b9b62-33eb-4b34-95eb-d43fe3e020ff"
+    },
+    {
+      "name": "E1 Spirit",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/E1+Spirit"
+    },
+    {
+      "name": "Eclipse",
+      "uuid": "c9b3ef78-9c47-4052-bf70-ecf32c55c001",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/c9b3ef78-9c47-4052-bf70-ecf32c55c001"
+    },
+    {
+      "name": "Endeavor",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Endeavor"
+    },
+    {
+      "name": "Expanse",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Expanse"
+    },
+    {
+      "name": "F7A Hornet Mk I",
+      "uuid": "8b7e0d33-21c1-4057-8e5b-bf391b5091b2",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/8b7e0d33-21c1-4057-8e5b-bf391b5091b2"
+    },
+    {
+      "name": "F7A Hornet Mk II",
+      "uuid": "6759360c-8b2f-4a89-b7c6-82e94b873c1b",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/6759360c-8b2f-4a89-b7c6-82e94b873c1b"
+    },
+    {
+      "name": "F7C Hornet Mk I",
+      "uuid": "933ca746-3c36-470f-8245-a247a3776455",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/933ca746-3c36-470f-8245-a247a3776455"
+    },
+    {
+      "name": "F7C Hornet Mk II",
+      "uuid": "fb231ba1-dba1-4c9f-823a-746c772ae92f",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/fb231ba1-dba1-4c9f-823a-746c772ae92f"
+    },
+    {
+      "name": "F7C Hornet Wildfire Mk I",
+      "uuid": "0af2064a-c02d-4801-a434-09d802ba6573",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/0af2064a-c02d-4801-a434-09d802ba6573"
+    },
+    {
+      "name": "F7C-M Super Hornet Heartseeker Mk I",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/b140e32f-a96b-462f-8c7b-e7243577b2f4"
+    },
+    {
+      "name": "F7C-M Super Hornet Heartseeker Mk II",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/6f8bfcc3-2ade-4976-a8e9-fd07de5c3601"
+    },
+    {
+      "name": "F7C-M Super Hornet Mk I",
+      "uuid": "4f83f89d-480b-4d1b-867a-13772742d828",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/4f83f89d-480b-4d1b-867a-13772742d828"
+    },
+    {
+      "name": "F7C-M Super Hornet Mk II",
+      "uuid": "8c2eefb6-d880-47c9-8fd0-1f88865d5511",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/8c2eefb6-d880-47c9-8fd0-1f88865d5511"
+    },
+    {
+      "name": "F7C-R Hornet Tracker Mk I",
+      "uuid": "95b11c76-31ea-4bf3-9894-fb29caecb927",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/95b11c76-31ea-4bf3-9894-fb29caecb927"
+    },
+    {
+      "name": "F7C-R Hornet Tracker Mk II",
+      "uuid": "3fbff8f5-90f0-4c97-93f2-62d180aa8736",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/3fbff8f5-90f0-4c97-93f2-62d180aa8736"
+    },
+    {
+      "name": "F7C-S Hornet Ghost Mk I",
+      "uuid": "63b90c8d-459c-4a27-8cf6-db706ffc49ae",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/63b90c8d-459c-4a27-8cf6-db706ffc49ae"
+    },
+    {
+      "name": "F7C-S Hornet Ghost Mk II",
+      "uuid": "6fa37a02-3d65-448c-a989-02d42d9574dc",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/6fa37a02-3d65-448c-a989-02d42d9574dc"
+    },
+    {
+      "name": "F8C Lightning",
+      "uuid": "663b6047-5b06-489c-a906-bc91fb7d6e63",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/663b6047-5b06-489c-a906-bc91fb7d6e63"
+    },
+    {
+      "name": "F8C Lightning Executive Edition",
+      "uuid": "b67123fd-72b3-43e7-bfb3-069d59ba6190",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/b67123fd-72b3-43e7-bfb3-069d59ba6190"
+    },
+    {
+      "name": "Fortune",
+      "uuid": "3d371fd4-50e2-4b5e-859f-1086e905c946",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/3d371fd4-50e2-4b5e-859f-1086e905c946"
+    },
+    {
+      "name": "Freelancer",
+      "uuid": "b4791030-9d64-4f98-85cb-ca106f868c5e",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/b4791030-9d64-4f98-85cb-ca106f868c5e"
+    },
+    {
+      "name": "Freelancer DUR",
+      "uuid": "34821163-e32e-42bf-99df-8f42ba66ef34",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/34821163-e32e-42bf-99df-8f42ba66ef34"
+    },
+    {
+      "name": "Freelancer MAX",
+      "uuid": "6c6e9731-3d70-4f1b-84c2-9dbf3c1f97c7",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/6c6e9731-3d70-4f1b-84c2-9dbf3c1f97c7"
+    },
+    {
+      "name": "Freelancer MIS",
+      "uuid": "4b6700e5-38bd-4d8d-9281-ef82996b135f",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/4b6700e5-38bd-4d8d-9281-ef82996b135f"
+    },
+    {
+      "name": "Fury",
+      "uuid": "96b11061-68ce-4896-9424-fc8804a410ae",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/96b11061-68ce-4896-9424-fc8804a410ae"
+    },
+    {
+      "name": "Fury LX",
+      "uuid": "83a450d1-e6b1-437e-9aee-18316ed34c29",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/83a450d1-e6b1-437e-9aee-18316ed34c29"
+    },
+    {
+      "name": "Fury MX",
+      "uuid": "469d850e-b86b-47fc-9ee2-df81d775ccc8",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/469d850e-b86b-47fc-9ee2-df81d775ccc8"
+    },
+    {
+      "name": "G12",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/G12"
+    },
+    {
+      "name": "G12a",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/G12a"
+    },
+    {
+      "name": "G12r",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/G12r"
+    },
+    {
+      "name": "Galaxy",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Galaxy"
+    },
+    {
+      "name": "Genesis",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Genesis"
+    },
+    {
+      "name": "Geotack Planetary Beacon",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Geotack+Planetary+Beacon"
+    },
+    {
+      "name": "Geotack-X Planetary Beacon",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Geotack-X+Planetary+Beacon"
+    },
+    {
+      "name": "Gladiator",
+      "uuid": "f3f7b2e8-1e11-4649-82c6-3106ec966655",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/f3f7b2e8-1e11-4649-82c6-3106ec966655"
+    },
+    {
+      "name": "Gladius",
+      "uuid": "b6b59889-7226-458e-a6b0-1c9392128a3c",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/b6b59889-7226-458e-a6b0-1c9392128a3c"
+    },
+    {
+      "name": "Gladius Valiant",
+      "uuid": "d6cb3db3-b1e0-47a5-8c62-a64285dbb675",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/d6cb3db3-b1e0-47a5-8c62-a64285dbb675"
+    },
+    {
+      "name": "Glaive",
+      "uuid": "e379e38c-459a-4705-be7d-49a5f5d7a928",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/e379e38c-459a-4705-be7d-49a5f5d7a928"
+    },
+    {
+      "name": "Golem",
+      "uuid": "b616b3ad-123c-40f2-80bd-b8f4109633aa",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/b616b3ad-123c-40f2-80bd-b8f4109633aa"
+    },
+    {
+      "name": "Guardian",
+      "uuid": "30e0f7ac-26fc-4d31-a231-af625511e37e",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/30e0f7ac-26fc-4d31-a231-af625511e37e"
+    },
+    {
+      "name": "Guardian MX",
+      "uuid": "aaa0cdcd-907c-4533-b3fc-181ede06076d",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/aaa0cdcd-907c-4533-b3fc-181ede06076d"
+    },
+    {
+      "name": "Guardian QI",
+      "uuid": "e98521b6-ea2f-4c10-9050-abc29d89d0e8",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/e98521b6-ea2f-4c10-9050-abc29d89d0e8"
+    },
+    {
+      "name": "Hammerhead",
+      "uuid": "d46f4de1-8dc1-473b-9739-88c9ba7e75a6",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/d46f4de1-8dc1-473b-9739-88c9ba7e75a6"
+    },
+    {
+      "name": "Hammerhead Best In Show Edition 2949",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Hammerhead+Best+In+Show+Edition+2949"
+    },
+    {
+      "name": "Hawk",
+      "uuid": "c0f1d217-388c-453a-b6c1-3cb5c2cfc4d8",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/c0f1d217-388c-453a-b6c1-3cb5c2cfc4d8"
+    },
+    {
+      "name": "Herald",
+      "uuid": "36726a9f-7e14-4942-bc4f-1a398b5bef6a",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/36726a9f-7e14-4942-bc4f-1a398b5bef6a"
+    },
+    {
+      "name": "HoverQuad",
+      "uuid": "16ff4365-ac34-4b09-a132-d52d51f688d4",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/16ff4365-ac34-4b09-a132-d52d51f688d4"
+    },
+    {
+      "name": "Hull A",
+      "uuid": "6ec72f64-2002-481c-b7c9-b132476ba6aa",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/6ec72f64-2002-481c-b7c9-b132476ba6aa"
+    },
+    {
+      "name": "Hull B",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Hull+B"
+    },
+    {
+      "name": "Hull C",
+      "uuid": "c4ceff45-d851-44b1-921b-bfef93a6cd6a",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/c4ceff45-d851-44b1-921b-bfef93a6cd6a"
+    },
+    {
+      "name": "Hull D",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Hull+D"
+    },
+    {
+      "name": "Hull E",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Hull+E"
+    },
+    {
+      "name": "Hurricane",
+      "uuid": "3a586d52-4829-4504-8e3a-4ee300bb40cc",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/3a586d52-4829-4504-8e3a-4ee300bb40cc"
+    },
+    {
+      "name": "Idris-M",
+      "uuid": "f0caa993-4c6b-4402-8ef1-d91879060f3b",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/f0caa993-4c6b-4402-8ef1-d91879060f3b"
+    },
+    {
+      "name": "Idris-P",
+      "uuid": "4b0585b0-b60b-4c52-a744-d812e5e9ad58",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/4b0585b0-b60b-4c52-a744-d812e5e9ad58"
+    },
+    {
+      "name": "Intrepid",
+      "uuid": "16aa514f-12ac-43a4-b51d-44447252186e",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/16aa514f-12ac-43a4-b51d-44447252186e"
+    },
+    {
+      "name": "Ironclad",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Ironclad"
+    },
+    {
+      "name": "Ironclad Assault",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Ironclad+Assault"
+    },
+    {
+      "name": "Javelin",
+      "uuid": "05a4f566-36a4-495c-99a4-dbedc5105cb6",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/05a4f566-36a4-495c-99a4-dbedc5105cb6"
+    },
+    {
+      "name": "Khartu-Al",
+      "uuid": "8f61dc58-74ca-4dc6-aa95-c3105f10bba4",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/8f61dc58-74ca-4dc6-aa95-c3105f10bba4"
+    },
+    {
+      "name": "Kraken",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Kraken"
+    },
+    {
+      "name": "Kraken Privateer",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Kraken+Privateer"
+    },
+    {
+      "name": "L-21 Wolf",
+      "uuid": "1b201ef2-b4dd-46c2-978e-47a13e0a7f81",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/1b201ef2-b4dd-46c2-978e-47a13e0a7f81"
+    },
+    {
+      "name": "Legionnaire",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Legionnaire"
+    },
+    {
+      "name": "Liberator",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Liberator"
+    },
+    {
+      "name": "Lynx",
+      "uuid": "4c034eef-329c-4336-850e-49bfb1f06a15",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/4c034eef-329c-4336-850e-49bfb1f06a15"
+    },
+    {
+      "name": "M2 Hercules",
+      "uuid": "5cf39b3b-41d8-45c1-8ef2-d4678c7a7b85",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/5cf39b3b-41d8-45c1-8ef2-d4678c7a7b85"
+    },
+    {
+      "name": "M50",
+      "uuid": "1b57cdac-693b-410b-8343-68fa194c94ae",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/1b57cdac-693b-410b-8343-68fa194c94ae"
+    },
+    {
+      "name": "Mantis",
+      "uuid": "43f4f9c3-70ad-4549-8a10-0045afbbda10",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/43f4f9c3-70ad-4549-8a10-0045afbbda10"
+    },
+    {
+      "name": "Merchantman",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Merchantman"
+    },
+    {
+      "name": "Mercury",
+      "uuid": "c8e10f09-38a0-4730-9dd3-eb0a510c9e43",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/c8e10f09-38a0-4730-9dd3-eb0a510c9e43"
+    },
+    {
+      "name": "Meteor",
+      "uuid": "3155e6fd-e1c8-4c15-9bd1-f8e3c2c7174f",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/3155e6fd-e1c8-4c15-9bd1-f8e3c2c7174f"
+    },
+    {
+      "name": "MOLE",
+      "uuid": "ecdfd0df-6c5f-4183-a24b-9e1546e00a4e",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/ecdfd0df-6c5f-4183-a24b-9e1546e00a4e"
+    },
+    {
+      "name": "MPUV Cargo",
+      "uuid": "e19fc6c3-f5fa-4623-9a17-b00a29b71500",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/e19fc6c3-f5fa-4623-9a17-b00a29b71500"
+    },
+    {
+      "name": "MPUV Personnel",
+      "uuid": "e17ccf62-f2d2-4c4e-a132-a3000d40fbde",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/e17ccf62-f2d2-4c4e-a132-a3000d40fbde"
+    },
+    {
+      "name": "MPUV Tractor",
+      "uuid": "674e0a52-4469-4b55-ba0d-6aecc44d1728",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/674e0a52-4469-4b55-ba0d-6aecc44d1728"
+    },
+    {
+      "name": "MTC",
+      "uuid": "91c9418e-6240-4fb1-a18a-1e22ebfb7747",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/91c9418e-6240-4fb1-a18a-1e22ebfb7747"
+    },
+    {
+      "name": "Mule",
+      "uuid": "fb484074-f33f-4977-a052-2937e8508acc",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/fb484074-f33f-4977-a052-2937e8508acc"
+    },
+    {
+      "name": "Mustang Alpha",
+      "uuid": "a852bb00-e395-468f-9adc-78b3df9c82f6",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/a852bb00-e395-468f-9adc-78b3df9c82f6"
+    },
+    {
+      "name": "Mustang Alpha Vindicator",
+      "uuid": "439c5671-acad-4eb6-9f09-ba54165d1cb5",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/439c5671-acad-4eb6-9f09-ba54165d1cb5"
+    },
+    {
+      "name": "Mustang Beta",
+      "uuid": "973bc147-4422-48a6-99c8-6ff0ead25bdf",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/973bc147-4422-48a6-99c8-6ff0ead25bdf"
+    },
+    {
+      "name": "Mustang Delta",
+      "uuid": "f8c8fe5c-1aa3-41d7-86b0-6bb54b249541",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/f8c8fe5c-1aa3-41d7-86b0-6bb54b249541"
+    },
+    {
+      "name": "Mustang Gamma",
+      "uuid": "968249b2-ca7c-4b41-8f58-730673fefc8c",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/968249b2-ca7c-4b41-8f58-730673fefc8c"
+    },
+    {
+      "name": "Mustang Omega",
+      "uuid": "1164be4d-623e-4ef7-bc3d-4cdb45c22ec5",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/1164be4d-623e-4ef7-bc3d-4cdb45c22ec5"
+    },
+    {
+      "name": "Nautilus",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Nautilus"
+    },
+    {
+      "name": "Nautilus Solstice Edition",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Nautilus+Solstice+Edition"
+    },
+    {
+      "name": "Nomad",
+      "uuid": "34506e83-b7b8-4804-a7bb-f31f11bb9214",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/34506e83-b7b8-4804-a7bb-f31f11bb9214"
+    },
+    {
+      "name": "Nova",
+      "uuid": "b8a352bb-74a8-415b-9e08-77f684ac91b8",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/b8a352bb-74a8-415b-9e08-77f684ac91b8"
+    },
+    {
+      "name": "Nox",
+      "uuid": "daddeefa-fef0-4146-b630-a33d6e8904d3",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/daddeefa-fef0-4146-b630-a33d6e8904d3"
+    },
+    {
+      "name": "Nox Kue",
+      "uuid": "204a6ce4-1634-4f87-9955-04c70e44c8af",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/204a6ce4-1634-4f87-9955-04c70e44c8af"
+    },
+    {
+      "name": "Odyssey",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Odyssey"
+    },
+    {
+      "name": "Orion",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Orion"
+    },
+    {
+      "name": "P-52 Merlin",
+      "uuid": "a5a8e4e5-939c-4f7b-ab48-5f7db556d5a4",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/a5a8e4e5-939c-4f7b-ab48-5f7db556d5a4"
+    },
+    {
+      "name": "P-72 Archimedes",
+      "uuid": "70580bce-2347-4e96-9260-dee6394f483d",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/70580bce-2347-4e96-9260-dee6394f483d"
+    },
+    {
+      "name": "P-72 Archimedes Emerald",
+      "uuid": "ebee8a7f-8e4a-4bed-9e5d-76822724c9f0",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/ebee8a7f-8e4a-4bed-9e5d-76822724c9f0"
+    },
+    {
+      "name": "Paladin",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Paladin"
+    },
+    {
+      "name": "Perseus",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Perseus"
+    },
+    {
+      "name": "Pioneer",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Pioneer"
+    },
+    {
+      "name": "Pirate Gladius",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Pirate+Gladius"
+    },
+    {
+      "name": "Polaris",
+      "uuid": "565ffdd6-8122-4c24-a690-85aa5aade0ff",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/polaris"
+    },
+    {
+      "name": "Prospector",
+      "uuid": "f68ee841-88d1-46f3-a1e2-5dc71d9d5d97",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/f68ee841-88d1-46f3-a1e2-5dc71d9d5d97"
+    },
+    {
+      "name": "Prowler",
+      "uuid": "087b2253-2fc7-4fae-9f9d-97f64b7c43db",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/087b2253-2fc7-4fae-9f9d-97f64b7c43db"
+    },
+    {
+      "name": "Prowler Utility",
+      "uuid": "528fdddc-c97f-4ae8-a00e-11a59fc3662d",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/528fdddc-c97f-4ae8-a00e-11a59fc3662d"
+    },
+    {
+      "name": "PTV",
+      "uuid": "41ff82e7-ce4e-4dbc-ad7c-7ef52fbe569c",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/41ff82e7-ce4e-4dbc-ad7c-7ef52fbe569c"
+    },
+    {
+      "name": "Pulse",
+      "uuid": "48415834-ac12-4c28-ad01-7c210f30c2da",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/48415834-ac12-4c28-ad01-7c210f30c2da"
+    },
+    {
+      "name": "Pulse LX",
+      "uuid": "d1f27f85-90db-4b5d-8ac2-09a9e9ee1315",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/d1f27f85-90db-4b5d-8ac2-09a9e9ee1315"
+    },
+    {
+      "name": "RAFT",
+      "uuid": "cf9aa91e-15bf-435c-a22d-f2cadc4485ce",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/cf9aa91e-15bf-435c-a22d-f2cadc4485ce"
+    },
+    {
+      "name": "Railen",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Railen"
+    },
+    {
+      "name": "Ranger CV",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Ranger+CV"
+    },
+    {
+      "name": "Ranger RC",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Ranger+RC"
+    },
+    {
+      "name": "Ranger TR",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Ranger+TR"
+    },
+    {
+      "name": "Razor",
+      "uuid": "cec2111b-4c71-4968-8035-634de6561cf3",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/cec2111b-4c71-4968-8035-634de6561cf3"
+    },
+    {
+      "name": "Razor EX",
+      "uuid": "b17ef3ab-9518-40fd-803f-c2468175ccf6",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/b17ef3ab-9518-40fd-803f-c2468175ccf6"
+    },
+    {
+      "name": "Razor LX",
+      "uuid": "203cb135-4f12-4a23-bd53-30910134bac8",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/203cb135-4f12-4a23-bd53-30910134bac8"
+    },
+    {
+      "name": "Reclaimer",
+      "uuid": "f05b74b2-06cf-44d0-8607-c09487359384",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/f05b74b2-06cf-44d0-8607-c09487359384"
+    },
+    {
+      "name": "Reclaimer Best In Show Edition 2949",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Reclaimer+Best+In+Show+Edition+2949"
+    },
+    {
+      "name": "Redeemer",
+      "uuid": "9a25d006-5706-4c70-9ac6-df795688fe09",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/9a25d006-5706-4c70-9ac6-df795688fe09"
+    },
+    {
+      "name": "Reliant Kore",
+      "uuid": "3c9af040-d919-4afc-b768-45821a5b913c",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/3c9af040-d919-4afc-b768-45821a5b913c"
+    },
+    {
+      "name": "Reliant Mako",
+      "uuid": "c6cfa4d9-e794-4bb6-8da9-54cb779ea109",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/c6cfa4d9-e794-4bb6-8da9-54cb779ea109"
+    },
+    {
+      "name": "Reliant Sen",
+      "uuid": "e32d125f-a3f8-4bc7-b0e6-cb7edf22b7ac",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/e32d125f-a3f8-4bc7-b0e6-cb7edf22b7ac"
+    },
+    {
+      "name": "Reliant Tana",
+      "uuid": "c2956880-b82a-42d0-962b-eb736dac1536",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/c2956880-b82a-42d0-962b-eb736dac1536"
+    },
+    {
+      "name": "Retaliator",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Retaliator"
+    },
+    {
+      "name": "Retaliator Bomber",
+      "uuid": "93e1a434-f4fa-43ee-a40c-71bcae5073bc",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/93e1a434-f4fa-43ee-a40c-71bcae5073bc"
+    },
+    {
+      "name": "ROC",
+      "uuid": "62e33393-5d68-4191-aba5-3b81ce4f3bf9",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/62e33393-5d68-4191-aba5-3b81ce4f3bf9"
+    },
+    {
+      "name": "ROC-DS",
+      "uuid": "14d6ba03-86ad-47f8-b940-e8a82d2d52b6",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/14d6ba03-86ad-47f8-b940-e8a82d2d52b6"
+    },
+    {
+      "name": "Sabre",
+      "uuid": "17276ad3-7636-40b8-969a-877a2b439b37",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/17276ad3-7636-40b8-969a-877a2b439b37"
+    },
+    {
+      "name": "Sabre Comet",
+      "uuid": "9e4b2b2b-1b5a-4d53-84a2-fe6ed1e43172",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/9e4b2b2b-1b5a-4d53-84a2-fe6ed1e43172"
+    },
+    {
+      "name": "Sabre Firebird",
+      "uuid": "b9bc6679-81ad-472b-8b98-866c72fe6a89",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/b9bc6679-81ad-472b-8b98-866c72fe6a89"
+    },
+    {
+      "name": "Sabre Peregrine",
+      "uuid": "ac7ec306-b272-432e-8284-491da614419c",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/ac7ec306-b272-432e-8284-491da614419c"
+    },
+    {
+      "name": "Sabre Raven",
+      "uuid": "34615358-6b8e-4c27-b29e-f936e254e2a3",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/34615358-6b8e-4c27-b29e-f936e254e2a3"
+    },
+    {
+      "name": "San'tok.yāi",
+      "uuid": "9634b4d6-9f5a-4ad2-8574-431c15e3bc5d",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/9634b4d6-9f5a-4ad2-8574-431c15e3bc5d"
+    },
+    {
+      "name": "Scorpius",
+      "uuid": "edc1421b-59ee-4233-b292-abc2c3ea0a1a",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/edc1421b-59ee-4233-b292-abc2c3ea0a1a"
+    },
+    {
+      "name": "Scorpius Antares",
+      "uuid": "2f88be37-7825-4fe1-afae-2ca9d2b01114",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/2f88be37-7825-4fe1-afae-2ca9d2b01114"
+    },
+    {
+      "name": "Scythe",
+      "uuid": "28f22bb8-9f1c-4a46-9a39-20bcb1e5000e",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/28f22bb8-9f1c-4a46-9a39-20bcb1e5000e"
+    },
+    {
+      "name": "Spartan",
+      "uuid": "9c26b25a-9285-4074-94d1-163db2aa8cbb",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/9c26b25a-9285-4074-94d1-163db2aa8cbb"
+    },
+    {
+      "name": "SRV",
+      "uuid": "1810d1a7-61e3-4d95-bafb-0f11758c7683",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/1810d1a7-61e3-4d95-bafb-0f11758c7683"
+    },
+    {
+      "name": "Starfarer",
+      "uuid": "13a02a6d-7d67-4d22-8530-d4d2c8443f66",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/13a02a6d-7d67-4d22-8530-d4d2c8443f66"
+    },
+    {
+      "name": "Starfarer Gemini",
+      "uuid": "c989caf2-84a5-4c01-b99e-5fc9f8d0ce8e",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/c989caf2-84a5-4c01-b99e-5fc9f8d0ce8e"
+    },
+    {
+      "name": "Starlancer MAX",
+      "uuid": "ff873dda-2b79-4fa3-b3ce-535b8adff5e2",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/ff873dda-2b79-4fa3-b3ce-535b8adff5e2"
+    },
+    {
+      "name": "Starlancer TAC",
+      "uuid": "14b8caeb-d5e1-4816-9537-86ef19afada8",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/14b8caeb-d5e1-4816-9537-86ef19afada8"
+    },
+    {
+      "name": "Storm",
+      "uuid": "515269d2-fea4-473f-b416-5f6677a54b55",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/515269d2-fea4-473f-b416-5f6677a54b55"
+    },
+    {
+      "name": "Storm AA",
+      "uuid": "8bbcd2cd-1e4b-4b0b-a65c-385bb2a02c32",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/8bbcd2cd-1e4b-4b0b-a65c-385bb2a02c32"
+    },
+    {
+      "name": "STV",
+      "uuid": "d4662193-10ab-4912-8ca4-d64ead0e6f3b",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/d4662193-10ab-4912-8ca4-d64ead0e6f3b"
+    },
+    {
+      "name": "Syulen",
+      "uuid": "11ebc47d-4763-4faa-9020-171cf6c2651f",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/11ebc47d-4763-4faa-9020-171cf6c2651f"
+    },
+    {
+      "name": "Talon",
+      "uuid": "41a84db8-062b-4359-ad16-611ad540fbdb",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/41a84db8-062b-4359-ad16-611ad540fbdb"
+    },
+    {
+      "name": "Talon Shrike",
+      "uuid": "2000c8d9-f151-4148-babe-6d9e413e2114",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/2000c8d9-f151-4148-babe-6d9e413e2114"
+    },
+    {
+      "name": "Terrapin",
+      "uuid": "0920e187-515d-466a-9c6a-a7dde9d2b1bc",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/0920e187-515d-466a-9c6a-a7dde9d2b1bc"
+    },
+    {
+      "name": "Terrapin Medic",
+      "uuid": "35f6ad71-01c6-4762-a18b-99c7fdde9760",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/35f6ad71-01c6-4762-a18b-99c7fdde9760"
+    },
+    {
+      "name": "Ursa",
+      "uuid": "8c375d7e-0e44-42e8-b84b-c8d6b2e1256c",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/8c375d7e-0e44-42e8-b84b-c8d6b2e1256c"
+    },
+    {
+      "name": "Ursa Fortuna",
+      "uuid": "953f8277-43a5-4f88-b139-ee997ee5c482",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/953f8277-43a5-4f88-b139-ee997ee5c482"
+    },
+    {
+      "name": "Ursa Medivac",
+      "uuid": "ebf015be-7bf9-44e9-ad9c-b5c65f00c530",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/ebf015be-7bf9-44e9-ad9c-b5c65f00c530"
+    },
+    {
+      "name": "Valkyrie",
+      "uuid": "881e3879-a186-44da-8b47-1d8f0a846438",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/881e3879-a186-44da-8b47-1d8f0a846438"
+    },
+    {
+      "name": "Valkyrie Liberator Edition",
+      "uuid": "4e62ae95-d173-4b94-8b91-9d85bc963ba1",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/4e62ae95-d173-4b94-8b91-9d85bc963ba1"
+    },
+    {
+      "name": "Vanguard Harbinger",
+      "uuid": "34295443-da9b-4e6c-9335-69d5f3b29a88",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/34295443-da9b-4e6c-9335-69d5f3b29a88"
+    },
+    {
+      "name": "Vanguard Hoplite",
+      "uuid": "f80d39f3-50fc-4fca-ada1-76de4c237e3f",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/f80d39f3-50fc-4fca-ada1-76de4c237e3f"
+    },
+    {
+      "name": "Vanguard Sentinel",
+      "uuid": "8aa6a16e-6c06-4db8-ac6d-165f97bf2565",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/8aa6a16e-6c06-4db8-ac6d-165f97bf2565"
+    },
+    {
+      "name": "Vanguard Warden",
+      "uuid": "a8208d11-32d4-4a4a-82c4-fd7f498b2ae6",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/a8208d11-32d4-4a4a-82c4-fd7f498b2ae6"
+    },
+    {
+      "name": "Vulcan",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Vulcan"
+    },
+    {
+      "name": "Vulture",
+      "uuid": "34077e67-5e2c-4903-a17c-2d0e163751c7",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/34077e67-5e2c-4903-a17c-2d0e163751c7"
+    },
+    {
+      "name": "X1",
+      "uuid": "829d0525-e67e-4e57-9f52-b4e572a4f73d",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/829d0525-e67e-4e57-9f52-b4e572a4f73d"
+    },
+    {
+      "name": "X1 Force",
+      "uuid": "b416dbbf-53f2-489e-a9dc-456286aa6c70",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/b416dbbf-53f2-489e-a9dc-456286aa6c70"
+    },
+    {
+      "name": "X1 Velocity",
+      "uuid": "58e25524-8bd3-450f-8442-7b58fdfc8a50",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/58e25524-8bd3-450f-8442-7b58fdfc8a50"
+    },
+    {
+      "name": "Zeus Mk II CL",
+      "uuid": "02fe3279-3598-4ce6-96dc-0bc5cb90dfdc",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/02fe3279-3598-4ce6-96dc-0bc5cb90dfdc"
+    },
+    {
+      "name": "Zeus Mk II ES",
+      "uuid": "e4770804-b43a-4c2d-a4e4-fedd410e50fb",
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/e4770804-b43a-4c2d-a4e4-fedd410e50fb"
+    },
+    {
+      "name": "Zeus Mk II MR",
+      "uuid": null,
+      "link": "https://api.star-citizen.wiki/api/v2/vehicles/Zeus+Mk+II+MR"
+    }
+  ]
+}

--- a/db-builder/working/temp-ships.json
+++ b/db-builder/working/temp-ships.json
@@ -1,0 +1,19752 @@
+{
+  "version": "1.0.5",
+  "ships": {
+    "ORIG_100i": {
+      "name": "100i",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 654000,
+        "crew": 1,
+        "cargo": 2,
+        "stowage": 930000,
+        "speed": {
+          "max": 1425,
+          "scm": 260,
+          "roll": 195,
+          "pitch": 50,
+          "yaw": 50
+        },
+        "emission": {
+          "ir": 7472,
+          "em_idle": 6263,
+          "em_max": 20675
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 6.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 2,
+          "missle-class": "misl_s02_cs_thcn_strikeforce"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Origin Jumpworks Noise Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Origin Jumpworks Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 1650,
+        "wing (left)": 800,
+        "wing (right)": 800,
+        "spoiler": 650
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s01_web_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s01_powerbolt_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_lplt_s01_arcticstorm_scitem"
+          },
+          {
+            "class": "cool_lplt_s01_arcticstorm_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s01_expedition_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ORIG_125a": {
+      "name": "125a",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 791000,
+        "crew": 1,
+        "cargo": 2,
+        "stowage": 930000,
+        "speed": {
+          "max": 1425,
+          "scm": 260,
+          "roll": 200,
+          "pitch": 70,
+          "yaw": 52
+        },
+        "emission": {
+          "ir": 7537,
+          "em_idle": 6313,
+          "em_max": 21928
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 6.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 6,
+          "missle-class": "misl_s02_cs_thcn_strikeforce"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Origin Jumpworks Noise Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Origin Jumpworks Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 1650,
+        "wing (left)": 800,
+        "wing (right)": 800,
+        "spoiler": 650
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s01_expedition_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "ORIG_135c": {
+      "name": "135c",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 839000,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 930000,
+        "speed": {
+          "max": 1425,
+          "scm": 260,
+          "roll": 212,
+          "pitch": 53,
+          "yaw": 53
+        },
+        "emission": {
+          "ir": 7340,
+          "em_idle": 6263,
+          "em_max": 22006
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 6.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 2,
+          "missle-class": "misl_s02_cs_thcn_strikeforce"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Origin Jumpworks Noise Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Origin Jumpworks Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 1650,
+        "wing (left)": 800,
+        "wing (right)": 800,
+        "spoiler": 650
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s01_fortitude_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s01_thermax_scitem"
+          },
+          {
+            "class": "cool_just_s01_thermax_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s01_expedition_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ORIG_300i": {
+      "name": "300i",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 767200,
+        "crew": 1,
+        "cargo": 8,
+        "stowage": 1010000,
+        "speed": {
+          "max": 1425,
+          "scm": 260,
+          "roll": 180,
+          "pitch": 52,
+          "yaw": 48
+        },
+        "emission": {
+          "ir": 6920,
+          "em_idle": 5895,
+          "em_max": 20316
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 10.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_ballisticrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_ballisticrepeater_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 2,
+          "missle-class": "misl_s02_cs_thcn_strikeforce"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Origin Jumpworks Noise Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Origin Jumpworks Noise Launcher"
+        }
+      ],
+      "health": {
+        "nose": 1650,
+        "wing (right bottom)": 800,
+        "wing flap (right)": 200,
+        "wing (right top)": 200,
+        "wing b (right)": 500,
+        "wing (left bottom)": 800,
+        "wing flap (left)": 200,
+        "wing (left top)": 200,
+        "wing b (left)": 500,
+        "tail": 1650,
+        "glass canopy (front)": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s01_web_scitem"
+          },
+          {
+            "class": "shld_seco_s01_web_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s01_powerbolt_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_lplt_s01_arcticstorm_scitem"
+          },
+          {
+            "class": "cool_lplt_s01_arcticstorm_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s01_expedition_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18",
+        "Traveler Rentals, Area 18",
+        "Traveler Rentals, Orison",
+        "Regal Luxury Rentals, New Babbage"
+      ]
+    },
+    "ORIG_315p": {
+      "name": "315p",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 882600,
+        "crew": 1,
+        "cargo": 12,
+        "stowage": 930000,
+        "speed": {
+          "max": 1425,
+          "scm": 260,
+          "roll": 180,
+          "pitch": 52,
+          "yaw": 48
+        },
+        "emission": {
+          "ir": 7213,
+          "em_idle": 5504,
+          "em_max": 19551
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 18
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_ballisticrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_ballisticrepeater_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 2,
+          "missle-class": "misl_s02_cs_fski_tempest"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Origin Jumpworks Noise Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Origin Jumpworks Noise Launcher"
+        }
+      ],
+      "health": {
+        "nose": 1650,
+        "wing (right bottom)": 800,
+        "wing flap (right)": 200,
+        "wing (right top)": 200,
+        "wing b (right)": 500,
+        "wing (left bottom)": 800,
+        "wing flap (left)": 200,
+        "wing (left top)": 200,
+        "wing b (left)": 500,
+        "tail": 1650,
+        "glass canopy (front)": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          },
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_tydt_s01_soniclite_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_tydt_s01_heatsafe_scitem"
+          },
+          {
+            "class": "cool_tydt_s01_heatsafe_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s01_goliath_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ORIG_325a": {
+      "name": "325a",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 944200,
+        "crew": 1,
+        "cargo": 4,
+        "stowage": 710000,
+        "speed": {
+          "max": 1425,
+          "scm": 260,
+          "roll": 180,
+          "pitch": 52,
+          "yaw": 48
+        },
+        "emission": {
+          "ir": 7075,
+          "em_idle": 5983,
+          "em_max": 21607
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 18
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_ballisticrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_ballisticrepeater_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 4,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        },
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_em_taln_dominator"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Origin Jumpworks Noise Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Origin Jumpworks Noise Launcher"
+        }
+      ],
+      "health": {
+        "nose": 1650,
+        "wing (right bottom)": 800,
+        "wing flap (right)": 200,
+        "wing (right top)": 200,
+        "wing b (right)": 500,
+        "wing (left bottom)": 800,
+        "wing flap (left)": 200,
+        "wing (left top)": 200,
+        "wing b (left)": 500,
+        "tail": 1650,
+        "glass canopy (front)": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          },
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s01_beacon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ORIG_350r": {
+      "name": "350r",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1602100,
+        "crew": 1,
+        "cargo": 4,
+        "stowage": 710000,
+        "speed": {
+          "max": 1425,
+          "scm": 260,
+          "roll": 180,
+          "pitch": 52,
+          "yaw": 48
+        },
+        "emission": {
+          "ir": 6620,
+          "em_idle": 6345,
+          "em_max": 20040
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 27
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 2,
+          "missle-class": "misl_s02_cs_thcn_strikeforce"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Origin Jumpworks Noise Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Origin Jumpworks Noise Launcher"
+        }
+      ],
+      "health": {
+        "nose": 850,
+        "wing (right bottom)": 100,
+        "wing flap (right)": 100,
+        "wing (right top)": 100,
+        "wing b (right)": 100,
+        "wing (left bottom)": 100,
+        "wing flap (left)": 100,
+        "wing (left top)": 100,
+        "wing b (left)": 50,
+        "tail": 1200,
+        "glass canopy (front)": 250
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_yorm_s01_targa_scitem"
+          },
+          {
+            "class": "shld_yorm_s01_targa_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_acom_s01_sunflare_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_acom_s01_quickcool_scitem"
+          },
+          {
+            "class": "cool_acom_s01_quickcool_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ORIG_400i": {
+      "name": "400i",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": 6352700,
+        "crew": 3,
+        "cargo": 42,
+        "stowage": 3810000,
+        "speed": {
+          "max": 1225,
+          "scm": 215,
+          "roll": 70,
+          "pitch": 35,
+          "yaw": 35
+        },
+        "emission": {
+          "ir": 11444,
+          "em_idle": 11222,
+          "em_max": 47122
+        },
+        "fuel": {
+          "quantum": 3.6,
+          "hydro": 60
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s4"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 16,
+          "missle-class": "misl_s02_cs_thcn_strikeforce"
+        },
+        {
+          "size": 1,
+          "count": 16,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 20000,
+        "bridge": 15000,
+        "wing (right)": 14000,
+        "wing (left)": 14000,
+        "nose": 17500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s03_guard_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s02_sedulity_scitem"
+          },
+          {
+            "class": "powr_just_s02_sedulity_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s02_snowfall_scitem"
+          },
+          {
+            "class": "cool_just_s02_snowfall_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_arcc_s02_torrent_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ORIG_600i": {
+      "name": "600i Explorer",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": 9475100,
+        "crew": 1,
+        "cargo": 44,
+        "stowage": 4460000,
+        "speed": {
+          "max": 975,
+          "scm": 165,
+          "roll": 30,
+          "pitch": 19,
+          "yaw": 19
+        },
+        "emission": {
+          "ir": 14847,
+          "em_idle": 19698,
+          "em_max": 51337
+        },
+        "fuel": {
+          "quantum": 5.1,
+          "hydro": 180
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 16,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "nose": 40000,
+        "front": 45000,
+        "hardpoint thruster mav (rear bottom front)": 50,
+        "hardpoint thruster mav side left (front)": 50,
+        "hardpoint thruster mav side right (front)": 50,
+        "hardpoint thruster mav (front bottom right)": 50,
+        "hardpoint thruster mav (front bottom left)": 50,
+        "hardpoint thruster mav (front top right)": 50,
+        "hardpoint thruster mav (front top left)": 50,
+        "body": 45000,
+        "tail": 45000,
+        "hardpoint main (lower left)": 50,
+        "hardpoint main (lower right)": 50,
+        "hardpoint main (upper right)": 50,
+        "hardpoint main (upper left)": 50,
+        "hardpoint fuel intake center": 50,
+        "hardpoint fuel intake (right)": 50,
+        "hardpoint fuel intake (left)": 50,
+        "hardpoint fuel tank (right)": 50,
+        "hardpoint fuel tank (left)": 50,
+        "hardpoint thruster retro (right)": 50,
+        "hardpoint thruster retro (left)": 50,
+        "hardpoint thruster mav (rear bottom back)": 50,
+        "hardpoint thruster mav (rear bottom right)": 50,
+        "hardpoint thruster mav (rear bottom left)": 50,
+        "wing (right)": 8625,
+        "hardpoint thruster mav side right (rear)": 50,
+        "hardpoint thruster mav (rear top right)": 50,
+        "wing (left)": 8625,
+        "hardpoint thruster mav side left (rear)": 50,
+        "hardpoint thruster mav (rear top left)": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          },
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s03_durango_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_lplt_s03_frostburn_scitem"
+          },
+          {
+            "class": "cool_lplt_s03_frostburn_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s02_odyssey_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18",
+        "Vantage Rentals, Lorville",
+        "Regal Luxury Rentals, New Babbage"
+      ]
+    },
+    "ORIG_600i_Touring": {
+      "name": "600i Touring",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": 9894000,
+        "crew": 1,
+        "cargo": 20,
+        "stowage": 4460000,
+        "speed": {
+          "max": 975,
+          "scm": 165,
+          "roll": 30,
+          "pitch": 19,
+          "yaw": 19
+        },
+        "emission": {
+          "ir": 14590,
+          "em_idle": 19697,
+          "em_max": 51331
+        },
+        "fuel": {
+          "quantum": 5.1,
+          "hydro": 180
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 16,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "nose": 40000,
+        "front": 45000,
+        "hardpoint thruster mav (rear bottom front)": 50,
+        "hardpoint thruster mav side left (front)": 50,
+        "hardpoint thruster mav side right (front)": 50,
+        "hardpoint thruster mav (front bottom right)": 50,
+        "hardpoint thruster mav (front bottom left)": 50,
+        "hardpoint thruster mav (front top right)": 50,
+        "hardpoint thruster mav (front top left)": 50,
+        "body": 45000,
+        "tail": 45000,
+        "hardpoint main (lower left)": 50,
+        "hardpoint main (lower right)": 50,
+        "hardpoint main (upper right)": 50,
+        "hardpoint main (upper left)": 50,
+        "hardpoint fuel intake center": 50,
+        "hardpoint fuel intake (right)": 50,
+        "hardpoint fuel intake (left)": 50,
+        "hardpoint fuel tank (right)": 50,
+        "hardpoint fuel tank (left)": 50,
+        "hardpoint thruster retro (right)": 50,
+        "hardpoint thruster retro (left)": 50,
+        "hardpoint thruster mav (rear bottom back)": 50,
+        "hardpoint thruster mav (rear bottom right)": 50,
+        "hardpoint thruster mav (rear bottom left)": 50,
+        "wing (right)": 8625,
+        "hardpoint thruster mav side right (rear)": 50,
+        "hardpoint thruster mav (rear top right)": 50,
+        "wing (left)": 8625,
+        "hardpoint thruster mav side left (rear)": 50,
+        "hardpoint thruster mav (rear top left)": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          },
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s03_durango_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_lplt_s03_frostburn_scitem"
+          },
+          {
+            "class": "cool_lplt_s03_frostburn_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s02_odyssey_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ORIG_85X": {
+      "name": "85X",
+      "stats": {
+        "ship-size": "snub",
+        "purchase-price": 574500,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 2940000,
+        "speed": {
+          "max": 1250,
+          "scm": 230,
+          "roll": 215,
+          "pitch": 65,
+          "yaw": 65
+        },
+        "emission": {
+          "ir": 8360,
+          "em_idle": 5820,
+          "em_max": 20150
+        },
+        "fuel": {
+          "quantum": 1,
+          "hydro": 4.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        }
+      ],
+      "missles": [],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Origin Jumpworks Noise Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Origin Jumpworks Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 1600,
+        "wing (right)": 600,
+        "wing (left)": 600
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_yorm_s01_targa_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s01_powerbolt_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_acom_s01_iceplunge_scitem"
+          },
+          {
+            "class": "cool_acom_s01_iceplunge_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s01_beacon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Regal Luxury Rentals, New Babbage"
+      ]
+    },
+    "ORIG_890Jump": {
+      "name": "890 Jump",
+      "stats": {
+        "ship-size": "capital",
+        "purchase-price": 32294500,
+        "crew": 1,
+        "cargo": 100,
+        "stowage": 7650000,
+        "speed": {
+          "max": 915,
+          "scm": 110,
+          "roll": 15,
+          "pitch": 10,
+          "yaw": 10
+        },
+        "emission": {
+          "ir": 22008,
+          "em_idle": 24183,
+          "em_max": 75713
+        },
+        "fuel": {
+          "quantum": 14.6,
+          "hydro": 1200
+        }
+      },
+      "weapons": [
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "orig_890j_scitem_turret_lower"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "orig_890j_scitem_turret_upper"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 8,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body (front)": 100000,
+        "body (front top)": 10000,
+        "glass bridge (right)": 200,
+        "glass bar (right)": 200,
+        "glass (right)": 200,
+        "glass bridge (left)": 200,
+        "glass bar (left)": 200,
+        "glass (left)": 200,
+        "glass dining": 200,
+        "glass bridge": 200,
+        "body": 10000,
+        "body (top)": 10000,
+        "glass (top)": 200,
+        "glass atrium (right)": 200,
+        "glass (rear)": 200,
+        "glass atrium (left)": 200,
+        "front": 10000,
+        "missilelauncher hatchdoorb tr": 200,
+        "missilelauncher hatchdoorb tl": 200,
+        "missilelauncher hatchdoora tr": 200,
+        "missilelauncher hatchdoora tl": 200,
+        "nose": 10000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_orig_s04_890j_scitem"
+          },
+          {
+            "class": "shld_orig_s04_890j_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_orig_s04_890j_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_orig_s04_890j_scitem"
+          },
+          {
+            "class": "cool_orig_s04_890j_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_orig_s04_890j_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Astro Armada, Area 18"
+      ]
+    },
+    "CRUS_Spirit_A1": {
+      "name": "A1 Spirit",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": null,
+        "crew": 2,
+        "cargo": 0,
+        "stowage": 1850000,
+        "speed": {
+          "max": 1130,
+          "scm": 203.5,
+          "roll": 101,
+          "pitch": 38,
+          "yaw": 30
+        },
+        "emission": {
+          "ir": 14685,
+          "em_idle": 5768,
+          "em_max": 31780
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 45
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 4,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 16500,
+        "wing base (right)": 10400,
+        "wing (right)": 1050,
+        "vtol geo (right)": 150,
+        "vtol flap geo (right)": 150,
+        "wing base (left)": 10400,
+        "wing (left)": 1050,
+        "vtol geo (left)": 150,
+        "vtol flap geo (left)": 150,
+        "rear": 11700,
+        "tail right": 1200,
+        "tail left": 1200,
+        "nose": 13500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_amrs_s02_ultraflux_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s02_boreal_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s02_yeager_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "CRUS_Starlifter_A2": {
+      "name": "A2 Hercules",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": 5525000,
+        "crew": 8,
+        "cargo": 216,
+        "stowage": 9140000,
+        "speed": {
+          "max": 950,
+          "scm": 160,
+          "roll": 30,
+          "pitch": 20,
+          "yaw": 18
+        },
+        "emission": {
+          "ir": 25679,
+          "em_idle": 35940,
+          "em_max": 72374
+        },
+        "fuel": {
+          "quantum": 6.6,
+          "hydro": 132
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "body": 65250,
+        "door right (front)": 4500,
+        "door left (front)": 4500,
+        "nose mesh": 10150,
+        "wing (right)": 8845,
+        "wing (left)": 8845,
+        "tail right": 5220,
+        "tail left": 5220
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s03_fullblock_scitem"
+          },
+          {
+            "class": "shld_godi_s03_fullblock_scitem"
+          },
+          {
+            "class": "shld_godi_s03_fullblock_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_amrs_s03_superdrive_scitem"
+          },
+          {
+            "class": "powr_amrs_s03_superdrive_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s03_mercury_scitem"
+          },
+          {
+            "class": "cool_aegs_s03_mercury_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s03_pontes_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Crusader Showroom, Orison"
+      ]
+    },
+    "ANVL_Ballista_Dunestalker": {
+      "name": "Anvil Ballista Dunestalker",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": null,
+        "crew": 2,
+        "cargo": 0,
+        "stowage": 2110000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 1790,
+          "em_idle": 3308,
+          "em_max": 16174
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s2"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "anvl ballista": 4200,
+        "hardpoint wheel 02 (back right)": 1700,
+        "hardpoint wheel 01 (back right)": 1700,
+        "hardpoint wheel 02 (back left)": 1700,
+        "hardpoint wheel 01 (back left)": 1700,
+        "hardpoint wheel 02 (front right)": 1700,
+        "hardpoint wheel 01 (front right)": 1700,
+        "hardpoint wheel 02 (front left)": 1700,
+        "hardpoint wheel 01 (front left)": 1700,
+        "body": 10000,
+        "nose": 10000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          },
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ANVL_Ballista_Snowblind": {
+      "name": "Anvil Ballista Snowblind",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": null,
+        "crew": 2,
+        "cargo": 0,
+        "stowage": 2110000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 1790,
+          "em_idle": 3308,
+          "em_max": 16174
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s2"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "anvl ballista": 4200,
+        "hardpoint wheel 02 (back right)": 1700,
+        "hardpoint wheel 01 (back right)": 1700,
+        "hardpoint wheel 02 (back left)": 1700,
+        "hardpoint wheel 01 (back left)": 1700,
+        "hardpoint wheel 02 (front right)": 1700,
+        "hardpoint wheel 01 (front right)": 1700,
+        "hardpoint wheel 02 (front left)": 1700,
+        "hardpoint wheel 01 (front left)": 1700,
+        "body": 10000,
+        "nose": 10000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          },
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "CRUS_Starfighter_Inferno": {
+      "name": "Ares Inferno",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": 2859000,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1720000,
+        "speed": {
+          "max": 1050,
+          "scm": 205,
+          "roll": 105,
+          "pitch": 37,
+          "yaw": 30
+        },
+        "emission": {
+          "ir": 8810,
+          "em_idle": 9784,
+          "em_max": 42494
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 45
+        }
+      },
+      "weapons": [],
+      "missles": [
+        {
+          "size": 3,
+          "count": 12,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        },
+        {
+          "size": 3,
+          "count": 8,
+          "missle-class": "misl_s03_ir_novp_viper"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 12000,
+        "nacelle debris (left)": 200,
+        "nacelle debris (right)": 200,
+        "canopy translation": 200,
+        "wing (left)": 7000,
+        "wing left (lower)": 1500,
+        "wing right (lower)": 1500,
+        "wing (right)": 7000,
+        "tail": 9000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          },
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          },
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          },
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s02_crossfield_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Crusader Showroom, Orison"
+      ]
+    },
+    "CRUS_Starfighter_Ion": {
+      "name": "Ares Ion",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 2859000,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1720000,
+        "speed": {
+          "max": 1050,
+          "scm": 205,
+          "roll": 105,
+          "pitch": 37,
+          "yaw": 30
+        },
+        "emission": {
+          "ir": 8870,
+          "em_idle": 10689,
+          "em_max": 43454
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 45
+        }
+      },
+      "weapons": [],
+      "missles": [
+        {
+          "size": 3,
+          "count": 12,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        },
+        {
+          "size": 3,
+          "count": 8,
+          "missle-class": "misl_s03_ir_novp_viper"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 12000,
+        "nacelle debris (left)": 200,
+        "nacelle debris (right)": 200,
+        "canopy translation": 200,
+        "wing (left)": 7000,
+        "wing left (lower)": 1500,
+        "wing right (lower)": 1500,
+        "wing (right)": 7000,
+        "tail": 9000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          },
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          },
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          },
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s02_crossfield_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Crusader Showroom, Orison"
+      ]
+    },
+    "ARGO_MOLE_Carbon": {
+      "name": "Argo Mole Carbon Edition",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": null,
+        "crew": 5,
+        "cargo": 96,
+        "stowage": 4570000,
+        "speed": {
+          "max": 960,
+          "scm": 140,
+          "roll": 75,
+          "pitch": 30,
+          "yaw": 30
+        },
+        "emission": {
+          "ir": 14399,
+          "em_idle": 41410,
+          "em_max": 76712
+        },
+        "fuel": {
+          "quantum": 2.6,
+          "hydro": 200
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "front": 22575,
+        "thruster vtol right (front)": 1200,
+        "thruster vtol left (front)": 1200,
+        "rear": 45000,
+        "thruster bot (right)": 2000,
+        "thruster (top right)": 2000,
+        "vtol (rear right)": 1200,
+        "thruster bot (left)": 2000,
+        "thruster (top left)": 2000,
+        "vtol (rear left)": 1200
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_behr_s03_5ca_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s03_ginzel_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s03_thermalcore_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s02_huracan_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ARGO_MOLE_Talus": {
+      "name": "Argo Mole Talus Edition",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": null,
+        "crew": 5,
+        "cargo": 96,
+        "stowage": 4570000,
+        "speed": {
+          "max": 960,
+          "scm": 140,
+          "roll": 75,
+          "pitch": 30,
+          "yaw": 30
+        },
+        "emission": {
+          "ir": 14399,
+          "em_idle": 41410,
+          "em_max": 76712
+        },
+        "fuel": {
+          "quantum": 2.6,
+          "hydro": 200
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "front": 22575,
+        "thruster vtol right (front)": 1200,
+        "thruster vtol left (front)": 1200,
+        "rear": 45000,
+        "thruster bot (right)": 2000,
+        "thruster (top right)": 2000,
+        "vtol (rear right)": 1200,
+        "thruster bot (left)": 2000,
+        "thruster (top left)": 2000,
+        "vtol (rear left)": 1200
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_behr_s03_5ca_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s03_ginzel_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s03_thermalcore_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s02_huracan_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ANVL_Arrow": {
+      "name": "Arrow",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 972300,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 860000,
+        "speed": {
+          "max": 1215,
+          "scm": 229,
+          "roll": 205,
+          "pitch": 75,
+          "yaw": 57
+        },
+        "emission": {
+          "ir": 6050,
+          "em_idle": 5043,
+          "em_max": 20385
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 7.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 3,
+          "missle-class": "misl_s02_em_taln_dominator"
+        },
+        {
+          "size": 2,
+          "count": 3,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Anvil Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Anvil Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 1950,
+        "stabilizer (right)": 800,
+        "stabilizer (left)": 800,
+        "wing (right)": 1500,
+        "wing (left)": 1500,
+        "nose": 1950,
+        "canopy": 80
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s01_beacon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18",
+        "Traveler Rentals, Area 18",
+        "Traveler Rentals, Orison",
+        "Vantage Rentals, Lorville"
+      ]
+    },
+    "ANVL_Asgard": {
+      "name": "Asgard",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 180,
+        "stowage": 0,
+        "speed": {
+          "max": 1075,
+          "scm": 203,
+          "roll": 95,
+          "pitch": 32.5,
+          "yaw": 27.5
+        },
+        "emission": {
+          "ir": 17856,
+          "em_idle": 22209,
+          "em_max": 57886
+        },
+        "fuel": {
+          "quantum": 1.85,
+          "hydro": 97.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "anvl_asgard_turret_bubble"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 16,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "engine rr split": 2500,
+        "engine rl split": 2500,
+        "engine fr split": 2500,
+        "engine fl split": 2500,
+        "nose": 20000,
+        "wing (left)": 4500,
+        "mesh wing flap (left)": 100,
+        "wing (right)": 4500,
+        "mesh wing flap (right)": 100,
+        "tail": 20000,
+        "wing (upper right)": 5000,
+        "mesh wing flap (upper right)": 100,
+        "wing (upper left)": 5000,
+        "mesh wing flap (upper left)": 100,
+        "mesh roof body": 200,
+        "wing rr": 3500,
+        "wing rl": 3500,
+        "mesh body (tail)": 200,
+        "tail top": 200
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          },
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          },
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          },
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s02_odyssey_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ARGO_ATLS": {
+      "name": "ATLS",
+      "stats": {
+        "ship-size": "undefined",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 0,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 300,
+          "em_idle": 41,
+          "em_max": 131
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {},
+      "components": {
+        "shields": [],
+        "power-plants": [],
+        "coolers": [],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ARGO_ATLS_GEO": {
+      "name": "ATLS GEO",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 0,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 791,
+          "em_idle": 1300,
+          "em_max": 13000
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {},
+      "components": {
+        "shields": [],
+        "power-plants": [],
+        "coolers": [],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "RSI_Aurora_CL": {
+      "name": "Aurora CL",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 487600,
+        "crew": 1,
+        "cargo": 6,
+        "stowage": 930000,
+        "speed": {
+          "max": 1150,
+          "scm": 220,
+          "roll": 135,
+          "pitch": 58,
+          "yaw": 53
+        },
+        "emission": {
+          "ir": 4549,
+          "em_idle": 3899,
+          "em_max": 19179
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 4.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 2,
+          "missle-class": "misl_s01_em_thcn_taskforce"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "nose": 1940,
+        "body": 1880,
+        "hardpoint retro thruster (right)": 50,
+        "hardpoint retro thruster (left)": 50,
+        "wing (top right)": 480,
+        "hardpoint mav thruster rb": 50,
+        "hardpoint mav thruster rr": 50,
+        "hardpoint mav thruster rl": 50,
+        "hardpoint mav thruster rt": 50,
+        "hardpoint main thruster": 50,
+        "wing (bottom right)": 480,
+        "wing (top left)": 480,
+        "wing (bottom left)": 480,
+        "hardpoint mav thruster fr": 50,
+        "hardpoint mav thruster fl": 50,
+        "hardpoint mav thruster fb": 50,
+        "hardpoint mav thruster ft": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          },
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s01_roughneck_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s01_hydrocel_scitem"
+          },
+          {
+            "class": "cool_just_s01_hydrocel_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "RSI_Aurora_ES": {
+      "name": "Aurora ES",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 124100,
+        "crew": 1,
+        "cargo": 3,
+        "stowage": 930000,
+        "speed": {
+          "max": 1180,
+          "scm": 222,
+          "roll": 140,
+          "pitch": 62,
+          "yaw": 57
+        },
+        "emission": {
+          "ir": 4589,
+          "em_idle": 3878,
+          "em_max": 17834
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 4.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "kbar_ballisticcannon_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "kbar_ballisticcannon_s1"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 2,
+          "missle-class": "misl_s01_em_thcn_taskforce"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "nose": 1940,
+        "body": 1880,
+        "hardpoint retro thruster (right)": 50,
+        "hardpoint retro thruster (left)": 50,
+        "wing (top right)": 480,
+        "hardpoint mav thruster rb": 50,
+        "hardpoint mav thruster rr": 50,
+        "hardpoint mav thruster rl": 50,
+        "hardpoint mav thruster rt": 50,
+        "hardpoint main thruster": 50,
+        "wing (bottom right)": 480,
+        "wing (top left)": 480,
+        "wing (bottom left)": 480,
+        "hardpoint mav thruster fr": 50,
+        "hardpoint mav thruster fl": 50,
+        "hardpoint mav thruster fb": 50,
+        "hardpoint mav thruster ft": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s01_ink_scitem"
+          },
+          {
+            "class": "shld_seco_s01_ink_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s01_zapjet_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_lplt_s01_blastchill_scitem"
+          },
+          {
+            "class": "cool_lplt_s01_blastchill_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Traveler Rentals, Area 18",
+        "Traveler Rentals, Orison",
+        "Vantage Rentals, Lorville"
+      ]
+    },
+    "RSI_Aurora_LN": {
+      "name": "Aurora LN",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 338400,
+        "crew": 1,
+        "cargo": 3,
+        "stowage": 710000,
+        "speed": {
+          "max": 1200,
+          "scm": 225,
+          "roll": 146,
+          "pitch": 65,
+          "yaw": 59
+        },
+        "emission": {
+          "ir": 3798,
+          "em_idle": 3445,
+          "em_max": 17958
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 4.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_em_taln_dominator"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "nose": 1940,
+        "body": 1880,
+        "hardpoint retro thruster (right)": 50,
+        "hardpoint retro thruster (left)": 50,
+        "wing (top right)": 480,
+        "hardpoint mav thruster rb": 50,
+        "hardpoint mav thruster rr": 50,
+        "hardpoint mav thruster rl": 50,
+        "hardpoint mav thruster rt": 50,
+        "hardpoint main thruster": 50,
+        "wing (bottom right)": 480,
+        "wing (top left)": 480,
+        "wing (bottom left)": 480,
+        "hardpoint mav thruster fr": 50,
+        "hardpoint mav thruster fl": 50,
+        "hardpoint mav thruster fb": 50,
+        "hardpoint mav thruster ft": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_securehyde_scitem"
+          },
+          {
+            "class": "shld_godi_s01_securehyde_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_charger_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Regal Luxury Rentals, New Babbage"
+      ]
+    },
+    "RSI_Aurora_LX": {
+      "name": "Aurora LX",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 245500,
+        "crew": 1,
+        "cargo": 3,
+        "stowage": 1010000,
+        "speed": {
+          "max": 1250,
+          "scm": 222,
+          "roll": 135,
+          "pitch": 58,
+          "yaw": 53
+        },
+        "emission": {
+          "ir": 4549,
+          "em_idle": 3899,
+          "em_max": 17579
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 4.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 2,
+          "missle-class": "misl_s02_cs_thcn_strikeforce"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "nose": 1940,
+        "body": 1880,
+        "hardpoint retro thruster (right)": 50,
+        "hardpoint retro thruster (left)": 50,
+        "wing (top right)": 480,
+        "hardpoint mav thruster rb": 50,
+        "hardpoint mav thruster rr": 50,
+        "hardpoint mav thruster rl": 50,
+        "hardpoint mav thruster rt": 50,
+        "hardpoint main thruster": 50,
+        "wing (bottom right)": 480,
+        "wing (top left)": 480,
+        "wing (bottom left)": 480,
+        "hardpoint mav thruster fr": 50,
+        "hardpoint mav thruster fl": 50,
+        "hardpoint mav thruster fb": 50,
+        "hardpoint mav thruster ft": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_yorm_s01_targa_scitem"
+          },
+          {
+            "class": "shld_yorm_s01_targa_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_acom_s01_lumacore_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_acom_s01_quickcool_scitem"
+          },
+          {
+            "class": "cool_acom_s01_quickcool_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "RSI_Aurora_MR": {
+      "name": "Aurora MR",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 184900,
+        "crew": 1,
+        "cargo": 3,
+        "stowage": 710000,
+        "speed": {
+          "max": 1230,
+          "scm": 227,
+          "roll": 137,
+          "pitch": 59,
+          "yaw": 51
+        },
+        "emission": {
+          "ir": 4549,
+          "em_idle": 3899,
+          "em_max": 19179
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 4.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 2,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "nose": 1940,
+        "body": 1880,
+        "hardpoint retro thruster (right)": 50,
+        "hardpoint retro thruster (left)": 50,
+        "wing (top right)": 480,
+        "hardpoint mav thruster rb": 50,
+        "hardpoint mav thruster rr": 50,
+        "hardpoint mav thruster rl": 50,
+        "hardpoint mav thruster rt": 50,
+        "hardpoint main thruster": 50,
+        "wing (bottom right)": 480,
+        "wing (top left)": 480,
+        "wing (bottom left)": 480,
+        "hardpoint mav thruster fr": 50,
+        "hardpoint mav thruster fl": 50,
+        "hardpoint mav thruster fb": 50,
+        "hardpoint mav thruster ft": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          },
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s01_roughneck_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s01_hydrocel_scitem"
+          },
+          {
+            "class": "cool_just_s01_hydrocel_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "AEGS_Avenger_Stalker": {
+      "name": "Avenger Stalker",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 882200,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 710000,
+        "speed": {
+          "max": 1425,
+          "scm": 260,
+          "roll": 180,
+          "pitch": 52.5,
+          "yaw": 48.5
+        },
+        "emission": {
+          "ir": 6428,
+          "em_idle": 5868,
+          "em_max": 20410
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 9
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticgatling_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 2,
+          "missle-class": "misl_s02_cs_fski_tempest"
+        },
+        {
+          "size": 2,
+          "count": 2,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 2500,
+        "hull (tail left)": 1000,
+        "fin flap (left tail)": 10,
+        "hull (tail right)": 1000,
+        "fin flap (right tail)": 10,
+        "wing (left)": 680,
+        "wingtip (left)": 1000,
+        "wing flap (left)": 10,
+        "wing (right)": 680,
+        "wingtip (right)": 1000,
+        "wing flap (right)": 10,
+        "nose": 2500,
+        "canopy": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          },
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s01_powerbolt_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s01_expedition_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "AEGS_Avenger_Titan": {
+      "name": "Avenger Titan",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 785600,
+        "crew": 1,
+        "cargo": 8,
+        "stowage": 1010000,
+        "speed": {
+          "max": 1425,
+          "scm": 260,
+          "roll": 180,
+          "pitch": 52.5,
+          "yaw": 48.5
+        },
+        "emission": {
+          "ir": 6512,
+          "em_idle": 5868,
+          "em_max": 21879
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 9
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticgatling_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 2500,
+        "hull (tail left)": 1000,
+        "fin flap (left tail)": 10,
+        "hull (tail right)": 1000,
+        "fin flap (right tail)": 10,
+        "wing (left)": 680,
+        "wingtip (left)": 1000,
+        "wing flap (left)": 10,
+        "wing (right)": 680,
+        "wingtip (right)": 1000,
+        "wing flap (right)": 10,
+        "nose": 2500,
+        "canopy": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          },
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s01_endurance_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s01_expedition_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Traveler Rentals, Area 18",
+        "Traveler Rentals, Orison",
+        "Vantage Rentals, Lorville",
+        "Traveler Rentals, Port Tressler",
+        "Traveler Rentals, Everus Harbor",
+        "Traveler Rentals, Baijini Point"
+      ]
+    },
+    "AEGS_Avenger_Titan_Renegade": {
+      "name": "Avenger Titan Renegade",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1076600,
+        "crew": 1,
+        "cargo": 8,
+        "stowage": 1010000,
+        "speed": {
+          "max": 1425,
+          "scm": 260,
+          "roll": 180,
+          "pitch": 52.5,
+          "yaw": 48.5
+        },
+        "emission": {
+          "ir": 6132,
+          "em_idle": 5867,
+          "em_max": 21651
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 9
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "kbar_ballisticcannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 2500,
+        "hull (tail left)": 1000,
+        "fin flap (left tail)": 10,
+        "hull (tail right)": 1000,
+        "fin flap (right tail)": 10,
+        "wing (left)": 680,
+        "wingtip (left)": 1000,
+        "wing flap (left)": 10,
+        "wing (right)": 680,
+        "wingtip (right)": 1000,
+        "wing flap (right)": 10,
+        "nose": 2500,
+        "canopy": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          },
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s01_endurance_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s01_expedition_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "AEGS_Avenger_Warlock": {
+      "name": "Avenger Warlock",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1155500,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 710000,
+        "speed": {
+          "max": 1425,
+          "scm": 260,
+          "roll": 180,
+          "pitch": 52.5,
+          "yaw": 48.5
+        },
+        "emission": {
+          "ir": 6728,
+          "em_idle": 6868,
+          "em_max": 23113
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 9
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticgatling_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 2,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        },
+        {
+          "size": 2,
+          "count": 2,
+          "missle-class": "misl_s02_em_taln_dominator"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 2500,
+        "hull (tail left)": 1000,
+        "fin flap (left tail)": 10,
+        "hull (tail right)": 1000,
+        "fin flap (right tail)": 10,
+        "wing (left)": 680,
+        "wingtip (left)": 1000,
+        "wing flap (left)": 10,
+        "wing (right)": 680,
+        "wingtip (right)": 1000,
+        "wing flap (right)": 10,
+        "nose": 2500,
+        "canopy": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          },
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s01_expedition_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Regal Luxury Rentals, New Babbage"
+      ]
+    },
+    "ANVL_Ballista": {
+      "name": "Ballista",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": 364500,
+        "crew": 2,
+        "cargo": 0,
+        "stowage": 2110000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 1790,
+          "em_idle": 3308,
+          "em_max": 16174
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s2"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "anvl ballista": 4200,
+        "hardpoint wheel 02 (back right)": 1700,
+        "hardpoint wheel 01 (back right)": 1700,
+        "hardpoint wheel 02 (back left)": 1700,
+        "hardpoint wheel 01 (back left)": 1700,
+        "hardpoint wheel 02 (front right)": 1700,
+        "hardpoint wheel 01 (front right)": 1700,
+        "hardpoint wheel 02 (front left)": 1700,
+        "hardpoint wheel 01 (front left)": 1700,
+        "body": 10000,
+        "nose": 10000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          },
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Astro Armada, Area 18"
+      ]
+    },
+    "VNCL_Blade": {
+      "name": "Blade",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 3370600,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1300000,
+        "speed": {
+          "max": 1191,
+          "scm": 227,
+          "roll": 195,
+          "pitch": 70,
+          "yaw": 52
+        },
+        "emission": {
+          "ir": 11091,
+          "em_idle": 7101,
+          "em_max": 22054
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 8
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "vncl_plasmacannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "vncl_plasmacannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "vncl_plasmacannon_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "vncl_plasmacannon_s2"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 8,
+          "missle-class": "misl_s01_ir_vncl_arrow"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 2150,
+        "wing (right)": 700,
+        "wing tip (right)": 275,
+        "belly": 750,
+        "rib1 (left)": 50,
+        "rib2 (left)": 50,
+        "rib3 (left)": 50,
+        "rib4 (left)": 50,
+        "rib5 (left)": 50,
+        "rib6 (left)": 50,
+        "rib7 (left)": 50,
+        "rib7 (right)": 50,
+        "rib6 (right)": 50,
+        "rib5 (right)": 50,
+        "rib4 (right)": 50,
+        "rib3 (right)": 50,
+        "rib2 (right)": 50,
+        "rib1 (right)": 50,
+        "wing (left)": 700,
+        "wing tip (left)": 275,
+        "spoiler": 250,
+        "nose": 2150
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          },
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_charger_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_acom_s01_iceplunge_scitem"
+          },
+          {
+            "class": "cool_acom_s01_iceplunge_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_arcc_s01_rush_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "DRAK_Buccaneer": {
+      "name": "Buccaneer",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1410100,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 900000,
+        "speed": {
+          "max": 1400,
+          "scm": 240,
+          "roll": 155,
+          "pitch": 49,
+          "yaw": 42
+        },
+        "emission": {
+          "ir": 9608,
+          "em_idle": 7634,
+          "em_max": 23557
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 7.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticgatling_s4"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 2,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        },
+        {
+          "size": 2,
+          "count": 2,
+          "missle-class": "misl_s02_cs_fski_tempest"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 1950,
+        "nose": 1950,
+        "landing gear attach (front)": 200,
+        "cockpit canopy door": 100,
+        "landing gear door right (front)": 100,
+        "landing gear door left (front)": 100,
+        "landing gear door center (front)": 100,
+        "landing gear attach (right)": 200,
+        "landing gear attach (left)": 200,
+        "flap right (tail)": 40,
+        "flap left (tail)": 40,
+        "intake (right)": 400,
+        "intake (left)": 400,
+        "engine (right)": 1000,
+        "wing (right)": 400,
+        "engine (left)": 1000,
+        "wing (left)": 400,
+        "landing gear door right (rear)": 300,
+        "landing gear door bottom (rear)": 300,
+        "landing gear door left (rear)": 300
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s01_web_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_amrs_s01_js300_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_arcc_s01_rush_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "CRUS_Spirit_C1": {
+      "name": "C1 Spirit",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": null,
+        "crew": 2,
+        "cargo": 64,
+        "stowage": 2460000,
+        "speed": {
+          "max": 1130,
+          "scm": 203.5,
+          "roll": 101,
+          "pitch": 38,
+          "yaw": 30
+        },
+        "emission": {
+          "ir": 14485,
+          "em_idle": 5219,
+          "em_max": 31325
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 45
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 4,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 16500,
+        "wing base (right)": 10400,
+        "wing (right)": 1050,
+        "vtol geo (right)": 150,
+        "vtol flap geo (right)": 150,
+        "wing base (left)": 10400,
+        "wing (left)": 1050,
+        "vtol geo (left)": 150,
+        "vtol flap geo (left)": 150,
+        "rear": 11700,
+        "tail right": 1200,
+        "tail left": 1200,
+        "nose": 13500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_amrs_s02_ultraflux_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s02_boreal_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s02_yeager_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "CRUS_Starlifter_C2": {
+      "name": "C2 Hercules",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": 4925500,
+        "crew": 2,
+        "cargo": 696,
+        "stowage": 2890000,
+        "speed": {
+          "max": 950,
+          "scm": 160,
+          "roll": 30,
+          "pitch": 20,
+          "yaw": 18
+        },
+        "emission": {
+          "ir": 14749,
+          "em_idle": 20560,
+          "em_max": 58486
+        },
+        "fuel": {
+          "quantum": 6.6,
+          "hydro": 132
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "body": 45000,
+        "door right (front)": 4500,
+        "door left (front)": 4500,
+        "nose mesh": 7000,
+        "wing (right)": 6600,
+        "wing (left)": 6600,
+        "tail right": 3600,
+        "tail left": 3600
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          },
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s03_ginzel_scitem"
+          },
+          {
+            "class": "powr_just_s03_ginzel_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s03_thermalcore_scitem"
+          },
+          {
+            "class": "cool_just_s03_thermalcore_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s03_kama_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18",
+        "Crusader Showroom, Orison"
+      ]
+    },
+    "ANVL_C8_Pisces": {
+      "name": "C8 Pisces",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 400000,
+        "crew": 1,
+        "cargo": 4,
+        "stowage": 710000,
+        "speed": {
+          "max": 1150,
+          "scm": 220,
+          "roll": 150,
+          "pitch": 60,
+          "yaw": 60
+        },
+        "emission": {
+          "ir": 5410,
+          "em_idle": 4683,
+          "em_max": 20065
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 3.2
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 2,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 4500,
+        "wing (right)": 250,
+        "wing debris (right)": 250,
+        "wing (left)": 250,
+        "wing debris (left)": 250,
+        "body underpanels (right)": 250,
+        "body underpanels (left)": 250,
+        "canopy": 250
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s01_expedition_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ANVL_C8R_Pisces": {
+      "name": "C8R Pisces",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 918000,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 710000,
+        "speed": {
+          "max": 1150,
+          "scm": 220,
+          "roll": 142,
+          "pitch": 56,
+          "yaw": 56
+        },
+        "emission": {
+          "ir": 5242,
+          "em_idle": 4683,
+          "em_max": 20062
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 3.2
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 2,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 4500,
+        "wing (right)": 250,
+        "wing debris (right)": 250,
+        "wing (left)": 250,
+        "wing debris (left)": 250,
+        "body underpanels (right)": 250,
+        "body underpanels (left)": 250,
+        "canopy": 250
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s01_expedition_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ANVL_C8X_Pisces_Expedition": {
+      "name": "C8X Pisces Expedition",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 406000,
+        "crew": 1,
+        "cargo": 4,
+        "stowage": 710000,
+        "speed": {
+          "max": 1150,
+          "scm": 220,
+          "roll": 150,
+          "pitch": 60,
+          "yaw": 60
+        },
+        "emission": {
+          "ir": 5470,
+          "em_idle": 4793,
+          "em_max": 20175
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 3.2
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "kron_lasercannon_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "kron_lasercannon_s1"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 2,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 4500,
+        "wing (right)": 250,
+        "wing debris (right)": 250,
+        "wing (left)": 250,
+        "wing debris (left)": 250,
+        "body underpanels (right)": 250,
+        "body underpanels (left)": 250,
+        "canopy": 250
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s01_expedition_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ANVL_Carrack": {
+      "name": "Carrack",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": 26657500,
+        "crew": 6,
+        "cargo": 456,
+        "stowage": 8920000,
+        "speed": {
+          "max": 1050,
+          "scm": 140,
+          "roll": 30,
+          "pitch": 16,
+          "yaw": 16
+        },
+        "emission": {
+          "ir": 18357,
+          "em_idle": 20818,
+          "em_max": 59514
+        },
+        "fuel": {
+          "quantum": 10.6,
+          "hydro": 360
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "anvl_carrack_scitem_turret_bubble"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "anvl_carrack_scitem_turret_side_left"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "anvl_carrack_scitem_turret_side_right"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "middle": 70000,
+        "front": 5000,
+        "rear": 3000,
+        "wings r": 5000,
+        "wings l": 5000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s03_barbican_scitem"
+          },
+          {
+            "class": "shld_basl_s03_barbican_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s03_reliance_scitem"
+          },
+          {
+            "class": "powr_just_s03_reliance_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s03_iceflush_scitem"
+          },
+          {
+            "class": "cool_just_s03_iceflush_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s03_kama_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ANVL_Carrack_Expedition": {
+      "name": "Carrack Expedition",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": null,
+        "crew": 6,
+        "cargo": 456,
+        "stowage": 8920000,
+        "speed": {
+          "max": 1050,
+          "scm": 140,
+          "roll": 30,
+          "pitch": 16,
+          "yaw": 16
+        },
+        "emission": {
+          "ir": 18357,
+          "em_idle": 20818,
+          "em_max": 59514
+        },
+        "fuel": {
+          "quantum": 10.6,
+          "hydro": 360
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "anvl_carrack_scitem_turret_bubble"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "anvl_carrack_scitem_turret_side_left"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "anvl_carrack_scitem_turret_side_right"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "middle": 70000,
+        "front": 5000,
+        "rear": 3000,
+        "wings r": 5000,
+        "wings l": 5000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s03_barbican_scitem"
+          },
+          {
+            "class": "shld_basl_s03_barbican_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s03_reliance_scitem"
+          },
+          {
+            "class": "powr_just_s03_reliance_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s03_iceflush_scitem"
+          },
+          {
+            "class": "cool_just_s03_iceflush_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s03_kama_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "DRAK_Caterpillar": {
+      "name": "Caterpillar",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": 4686600,
+        "crew": 1,
+        "cargo": 576,
+        "stowage": 32990000,
+        "speed": {
+          "max": 900,
+          "scm": 130,
+          "roll": 25,
+          "pitch": 16,
+          "yaw": 16
+        },
+        "emission": {
+          "ir": 24785,
+          "em_idle": 28732,
+          "em_max": 68790
+        },
+        "fuel": {
+          "quantum": 8.6,
+          "hydro": 250.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "drak_caterpillar_scitem_turret_bottom"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "drak_caterpillar_scitem_turret_top"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "body": 60000,
+        "nose": 25500,
+        "command module": 1200,
+        "engine (left)": 1500,
+        "engine (right)": 1500,
+        "engine center (right)": 1500,
+        "engine center (left)": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          },
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          },
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s03_ginzel_scitem"
+          },
+          {
+            "class": "powr_just_s03_ginzel_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s03_thermalcore_scitem"
+          },
+          {
+            "class": "cool_just_s03_thermalcore_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s03_pontes_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "DRAK_Caterpillar_Pirate": {
+      "name": "Caterpillar Pirate Edition",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 576,
+        "stowage": 32990000,
+        "speed": {
+          "max": 900,
+          "scm": 130,
+          "roll": 25,
+          "pitch": 16,
+          "yaw": 16
+        },
+        "emission": {
+          "ir": 24785,
+          "em_idle": 28732,
+          "em_max": 68790
+        },
+        "fuel": {
+          "quantum": 8.6,
+          "hydro": 250.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "drak_caterpillar_scitem_turret_bottom"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "drak_caterpillar_scitem_turret_top"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "body": 60000,
+        "nose": 25500,
+        "command module": 1200,
+        "engine (left)": 1500,
+        "engine (right)": 1500,
+        "engine center (right)": 1500,
+        "engine center (left)": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          },
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          },
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s03_ginzel_scitem"
+          },
+          {
+            "class": "powr_just_s03_ginzel_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s03_thermalcore_scitem"
+          },
+          {
+            "class": "cool_just_s03_thermalcore_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s03_pontes_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ANVL_Centurion": {
+      "name": "Centurion",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": 287400,
+        "crew": 2,
+        "cargo": 0,
+        "stowage": 2110000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 4652,
+          "em_idle": 3060,
+          "em_max": 17874
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "hardpoint wheel 04 (right)": 1700,
+        "hardpoint wheel 03 (right)": 1700,
+        "hardpoint wheel 02 (right)": 1700,
+        "hardpoint wheel 01 (right)": 1700,
+        "hardpoint wheel 04 (left)": 1700,
+        "hardpoint wheel 03 (left)": 1700,
+        "hardpoint wheel 02 (left)": 1700,
+        "hardpoint wheel 01 (left)": 1700,
+        "nose": 10000,
+        "body": 10000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s00_castra_scitem"
+          },
+          {
+            "class": "shld_basl_s00_castra_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s00_defiant_scitem"
+          },
+          {
+            "class": "powr_amrs_s01_overdrive_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_cryostarsl_scitem"
+          },
+          {
+            "class": "cool_jspn_s01_froststar_scitem"
+          },
+          {
+            "class": "cool_jspn_s01_froststar_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Astro Armada, Area 18"
+      ]
+    },
+    "RSI_Constellation_Andromeda": {
+      "name": "Constellation Andromeda",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": 3548000,
+        "crew": 1,
+        "cargo": 96,
+        "stowage": 5080000,
+        "speed": {
+          "max": 1000,
+          "scm": 190,
+          "roll": 45,
+          "pitch": 25,
+          "yaw": 21
+        },
+        "emission": {
+          "ir": 18225,
+          "em_idle": 10408,
+          "em_max": 37631
+        },
+        "fuel": {
+          "quantum": 4.1,
+          "hydro": 66
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s5"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "rsi_constellation_scitem_turret_lower"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "rsi_constellation_scitem_turret_upper"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 28,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        },
+        {
+          "size": 2,
+          "count": 24,
+          "missle-class": "misl_s02_cs_thcn_strikeforce"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        },
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        }
+      ],
+      "health": {
+        "rsi constellation": 500,
+        "body": 20000,
+        "nacelle (bottom left)": 15000,
+        "hardpoint thruster vtol 02 (rear left)": 50,
+        "hardpoint thruster vtol 01 (rear left)": 50,
+        "turbine cover nacellel in (top rear)": 20,
+        "turbine cover nacellel in (top front)": 20,
+        "turbine cover nacellel out (top rear)": 20,
+        "turbine cover nacellel out (top front)": 20,
+        "turbine cover nacellel bot in (rear)": 20,
+        "turbine cover nacellel bot in (front)": 20,
+        "turbine cover nacellel bot out (rear)": 20,
+        "turbine cover nacellel bot out (front)": 20,
+        "hardpoint thruster (bottom back left)": 50,
+        "nacelle (bottom right)": 15000,
+        "hardpoint thruster vtol 02 (rear right)": 50,
+        "hardpoint thruster vtol 01 (rear right)": 50,
+        "turbine cover naceller out (top rear)": 20,
+        "turbine cover naceller out (top front)": 20,
+        "turbine cover naceller in (top rear)": 20,
+        "turbine cover naceller in (top front)": 20,
+        "turbine cover naceller bot out (rear)": 20,
+        "turbine cover naceller bot out (front)": 20,
+        "turbine cover naceller bot in (rear)": 20,
+        "turbine cover naceller bot in (front)": 20,
+        "hardpoint thruster (bottom back right)": 50,
+        "tail": 20000,
+        "misslerack arm arm (tail right)": 1750,
+        "nacelle tower (right)": 1000,
+        "nacelle (right)": 15000,
+        "hardpoint thruster (top back right)": 50,
+        "nacelle tower (left)": 1000,
+        "nacelle (left)": 15000,
+        "hardpoint thruster (top back left)": 50,
+        "hardpoint thruster center (back left)": 50,
+        "hardpoint thruster center (back right)": 50,
+        "misslerack arm arm (tail left)": 1750,
+        "misslerack arm body arm (right)": 1750,
+        "misslerack arm body arm (left)": 1750,
+        "hardpoint lightgroup": 200,
+        "neck": 20000,
+        "nose": 20000,
+        "nose turret door (top right)": 1,
+        "nose turret door (top left)": 1,
+        "nose turret door (bottom right)": 1,
+        "nose turret door (bottom left)": 1,
+        "wing (right)": 15000,
+        "hardpoint thruster vtol 02 (front right)": 50,
+        "hardpoint thruster vtol 01 (front right)": 50,
+        "turbine cover wingr bot out (rear)": 20,
+        "turbine cover wingr bot in (front)": 20,
+        "turbine cover wingr out (top front)": 20,
+        "turbine cover wingr out (top rear)": 20,
+        "turbine cover wingr bot out (front)": 20,
+        "turbine cover wingr bot in (rear)": 20,
+        "turbine cover wingr in (top front)": 20,
+        "turbine cover wingr in (top rear)": 20,
+        "hardpoint thruster center (front right)": 50,
+        "wing (left)": 15000,
+        "hardpoint thruster vtol 02 (front left)": 50,
+        "hardpoint thruster vtol 01 (front left)": 50,
+        "turbine cover wingl in (top rear)": 20,
+        "turbine cover wingl in (top front)": 20,
+        "turbine cover wingl out (top rear)": 20,
+        "turbine cover wingl out (top front)": 20,
+        "turbine cover wingl bot in (rear)": 20,
+        "turbine cover wingl bot in (front)": 20,
+        "turbine cover wingl bot out (rear)": 20,
+        "turbine cover wingl bot out (front)": 20,
+        "hardpoint thruster center (front left)": 50,
+        "hardpoint thruster (bottom front left)": 50,
+        "hardpoint thruster (top front left)": 50,
+        "hardpoint thruster (top front right)": 50,
+        "hardpoint thruster (bottom front right)": 50,
+        "nose turrethousings": 500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_behr_s03_5ca_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_sasu_s02_daybreak_scitem"
+          },
+          {
+            "class": "powr_sasu_s02_daybreak_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s02_froststarex_scitem"
+          },
+          {
+            "class": "cool_jspn_s02_froststarex_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s02_bolon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Traveler Rentals, Area 18",
+        "Traveler Rentals, Orison",
+        "Vantage Rentals, Lorville",
+        "Regal Luxury Rentals, New Babbage"
+      ]
+    },
+    "RSI_Constellation_Aquila": {
+      "name": "Constellation Aquila",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": 4926700,
+        "crew": 1,
+        "cargo": 96,
+        "stowage": 5600000,
+        "speed": {
+          "max": 1075,
+          "scm": 180,
+          "roll": 45,
+          "pitch": 25,
+          "yaw": 21
+        },
+        "emission": {
+          "ir": 16825,
+          "em_idle": 9208,
+          "em_max": 36791
+        },
+        "fuel": {
+          "quantum": 5.6,
+          "hydro": 104.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "rsi_constellation_scitem_turret_lower"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "rsi_constellation_aquila_scitem_turret_radar"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 24,
+          "missle-class": "misl_s02_cs_thcn_strikeforce"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        },
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        }
+      ],
+      "health": {
+        "rsi constellation aquila": 500,
+        "body": 20000,
+        "nacelle (bottom left)": 15000,
+        "hardpoint thruster vtol 02 (rear left)": 50,
+        "hardpoint thruster vtol 01 (rear left)": 50,
+        "turbine cover nacellel in (top rear)": 20,
+        "turbine cover nacellel in (top front)": 20,
+        "turbine cover nacellel out (top rear)": 20,
+        "turbine cover nacellel out (top front)": 20,
+        "turbine cover nacellel bot in (rear)": 20,
+        "turbine cover nacellel bot in (front)": 20,
+        "turbine cover nacellel bot out (rear)": 20,
+        "turbine cover nacellel bot out (front)": 20,
+        "hardpoint thruster (bottom back left)": 50,
+        "nacelle (bottom right)": 15000,
+        "hardpoint thruster vtol 02 (rear right)": 50,
+        "hardpoint thruster vtol 01 (rear right)": 50,
+        "turbine cover naceller out (top rear)": 20,
+        "turbine cover naceller out (top front)": 20,
+        "turbine cover naceller in (top rear)": 20,
+        "turbine cover naceller in (top front)": 20,
+        "turbine cover naceller bot out (rear)": 20,
+        "turbine cover naceller bot out (front)": 20,
+        "turbine cover naceller bot in (rear)": 20,
+        "turbine cover naceller bot in (front)": 20,
+        "hardpoint thruster (bottom back right)": 50,
+        "tail": 20000,
+        "misslerack arm arm (tail right)": 1750,
+        "nacelle tower (right)": 1000,
+        "nacelle (right)": 15000,
+        "hardpoint thruster (top back right)": 50,
+        "nacelle tower (left)": 1000,
+        "nacelle (left)": 15000,
+        "hardpoint thruster (top back left)": 50,
+        "hardpoint thruster center (back left)": 50,
+        "hardpoint thruster center (back right)": 50,
+        "misslerack arm arm (tail left)": 1750,
+        "misslerack arm body arm (right)": 1750,
+        "misslerack arm body arm (left)": 1750,
+        "hardpoint lightgroup": 200,
+        "neck": 20000,
+        "nose": 20000,
+        "nose turret door (top right)": 1,
+        "nose turret door (top left)": 1,
+        "nose turret door (bottom right)": 1,
+        "nose turret door (bottom left)": 1,
+        "wing (right)": 15000,
+        "hardpoint thruster vtol 02 (front right)": 50,
+        "hardpoint thruster vtol 01 (front right)": 50,
+        "turbine cover wingr bot out (rear)": 20,
+        "turbine cover wingr bot in (front)": 20,
+        "turbine cover wingr out (top front)": 20,
+        "turbine cover wingr out (top rear)": 20,
+        "turbine cover wingr bot out (front)": 20,
+        "turbine cover wingr bot in (rear)": 20,
+        "turbine cover wingr in (top front)": 20,
+        "turbine cover wingr in (top rear)": 20,
+        "hardpoint thruster center (front right)": 50,
+        "wing (left)": 15000,
+        "hardpoint thruster vtol 02 (front left)": 50,
+        "hardpoint thruster vtol 01 (front left)": 50,
+        "turbine cover wingl in (top rear)": 20,
+        "turbine cover wingl in (top front)": 20,
+        "turbine cover wingl out (top rear)": 20,
+        "turbine cover wingl out (top front)": 20,
+        "turbine cover wingl bot in (rear)": 20,
+        "turbine cover wingl bot in (front)": 20,
+        "turbine cover wingl bot out (rear)": 20,
+        "turbine cover wingl bot out (front)": 20,
+        "hardpoint thruster center (front left)": 50,
+        "hardpoint thruster (bottom front left)": 50,
+        "hardpoint thruster (top front left)": 50,
+        "hardpoint thruster (top front right)": 50,
+        "hardpoint thruster (bottom front right)": 50,
+        "nose turret housings": 500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_behr_s03_5ca_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_sasu_s02_daybreak_scitem"
+          },
+          {
+            "class": "powr_sasu_s02_daybreak_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s02_froststarex_scitem"
+          },
+          {
+            "class": "cool_jspn_s02_froststarex_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s02_bolon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "RSI_Constellation_Phoenix": {
+      "name": "Constellation Phoenix",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": 5658800,
+        "crew": 1,
+        "cargo": 80,
+        "stowage": 5430000,
+        "speed": {
+          "max": 995,
+          "scm": 185,
+          "roll": 45,
+          "pitch": 25,
+          "yaw": 21
+        },
+        "emission": {
+          "ir": 17825,
+          "em_idle": 9768,
+          "em_max": 36991
+        },
+        "fuel": {
+          "quantum": 4.1,
+          "hydro": 66
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s5"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "rsi_constellation_phoenix_turret_lower"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "rsi_constellation_phoenix_turret_upper"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 28,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        },
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        }
+      ],
+      "health": {
+        "rsi constellation phoenix": 500,
+        "body": 20000,
+        "tail": 20000,
+        "nacelle tower (right)": 1000,
+        "nacelle (right)": 5500,
+        "hardpoint thruster (top back right)": 50,
+        "nacelle tower (left)": 1000,
+        "nacelle (left)": 5500,
+        "hardpoint thruster (top back left)": 50,
+        "misslerack arm arm (tail right)": 1750,
+        "hardpoint thruster center (back left)": 50,
+        "hardpoint thruster center (back right)": 50,
+        "misslerack arm arm (tail left)": 1750,
+        "nacelle (bottom left)": 15000,
+        "hardpoint thruster vtol 02 (rear left)": 50,
+        "hardpoint thruster vtol 01 (rear left)": 50,
+        "turbine cover nacellel in (top rear)": 20,
+        "turbine cover nacellel in (top front)": 20,
+        "turbine cover nacellel out (top rear)": 20,
+        "turbine cover nacellel out (top front)": 20,
+        "turbine cover nacellel bot in (rear)": 20,
+        "turbine cover nacellel bot in (front)": 20,
+        "turbine cover nacellel bot out (rear)": 20,
+        "turbine cover nacellel bot out (front)": 20,
+        "hardpoint thruster (bottom back left)": 50,
+        "nacelle (bottom right)": 15000,
+        "hardpoint thruster vtol 02 (rear right)": 50,
+        "hardpoint thruster vtol 01 (rear right)": 50,
+        "turbine cover naceller out (top rear)": 20,
+        "turbine cover naceller out (top front)": 20,
+        "turbine cover naceller in (top rear)": 20,
+        "turbine cover naceller in (top front)": 20,
+        "turbine cover naceller bot out (rear)": 20,
+        "turbine cover naceller bot out (front)": 20,
+        "turbine cover naceller bot in (rear)": 20,
+        "turbine cover naceller bot in (front)": 20,
+        "hardpoint thruster (bottom back right)": 50,
+        "misslerack arm body arm (right)": 1750,
+        "misslerack arm body arm (left)": 1750,
+        "neck": 20000,
+        "nose": 20000,
+        "nose turret door (top right)": 1,
+        "nose turret door (top left)": 1,
+        "nose turret door (bottom right)": 1,
+        "nose turret door (bottom left)": 1,
+        "nose turrethousings": 1,
+        "wing (left)": 15000,
+        "hardpoint thruster vtol 02 (front left)": 50,
+        "hardpoint thruster vtol 01 (front left)": 50,
+        "turbine cover wingl in (top rear)": 20,
+        "turbine cover wingl in (top front)": 20,
+        "turbine cover wingl out (top rear)": 20,
+        "turbine cover wingl out (top front)": 20,
+        "turbine cover wingl bot in (rear)": 20,
+        "turbine cover wingl bot in (front)": 20,
+        "turbine cover wingl bot out (rear)": 20,
+        "turbine cover wingl bot out (front)": 20,
+        "hardpoint thruster center (front left)": 50,
+        "wing (right)": 15000,
+        "hardpoint thruster vtol 02 (front right)": 50,
+        "hardpoint thruster vtol 01 (front right)": 50,
+        "turbine cover wingr bot out (rear)": 20,
+        "turbine cover wingr bot in (front)": 20,
+        "turbine cover wingr out (top front)": 20,
+        "turbine cover wingr out (top rear)": 20,
+        "turbine cover wingr bot out (front)": 20,
+        "turbine cover wingr bot in (rear)": 20,
+        "turbine cover wingr in (top front)": 20,
+        "turbine cover wingr in (top rear)": 20,
+        "hardpoint thruster center (front right)": 50,
+        "hardpoint thruster (top front right)": 50,
+        "hardpoint thruster (top front left)": 50,
+        "hardpoint thruster (bottom front right)": 50,
+        "hardpoint thruster (bottom front left)": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_behr_s03_5ca_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_sasu_s02_daybreak_scitem"
+          },
+          {
+            "class": "powr_sasu_s02_daybreak_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s02_froststarex_scitem"
+          },
+          {
+            "class": "cool_jspn_s02_froststarex_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s02_bolon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Regal Luxury Rentals, New Babbage"
+      ]
+    },
+    "RSI_Constellation_Phoenix_Emerald": {
+      "name": "Constellation Phoenix Emerald",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 80,
+        "stowage": 5430000,
+        "speed": {
+          "max": 995,
+          "scm": 185,
+          "roll": 45,
+          "pitch": 25,
+          "yaw": 21
+        },
+        "emission": {
+          "ir": 17825,
+          "em_idle": 9768,
+          "em_max": 36991
+        },
+        "fuel": {
+          "quantum": 4.1,
+          "hydro": 66
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s5"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "rsi_constellation_phoenix_turret_lower"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "rsi_constellation_phoenix_turret_upper"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 28,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        },
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        }
+      ],
+      "health": {
+        "rsi constellation phoenix": 500,
+        "body": 20000,
+        "tail": 20000,
+        "nacelle tower (right)": 1000,
+        "nacelle (right)": 5500,
+        "hardpoint thruster (top back right)": 50,
+        "nacelle tower (left)": 1000,
+        "nacelle (left)": 5500,
+        "hardpoint thruster (top back left)": 50,
+        "misslerack arm arm (tail right)": 1750,
+        "hardpoint thruster center (back left)": 50,
+        "hardpoint thruster center (back right)": 50,
+        "misslerack arm arm (tail left)": 1750,
+        "nacelle (bottom left)": 15000,
+        "hardpoint thruster vtol 02 (rear left)": 50,
+        "hardpoint thruster vtol 01 (rear left)": 50,
+        "turbine cover nacellel in (top rear)": 20,
+        "turbine cover nacellel in (top front)": 20,
+        "turbine cover nacellel out (top rear)": 20,
+        "turbine cover nacellel out (top front)": 20,
+        "turbine cover nacellel bot in (rear)": 20,
+        "turbine cover nacellel bot in (front)": 20,
+        "turbine cover nacellel bot out (rear)": 20,
+        "turbine cover nacellel bot out (front)": 20,
+        "hardpoint thruster (bottom back left)": 50,
+        "nacelle (bottom right)": 15000,
+        "hardpoint thruster vtol 02 (rear right)": 50,
+        "hardpoint thruster vtol 01 (rear right)": 50,
+        "turbine cover naceller out (top rear)": 20,
+        "turbine cover naceller out (top front)": 20,
+        "turbine cover naceller in (top rear)": 20,
+        "turbine cover naceller in (top front)": 20,
+        "turbine cover naceller bot out (rear)": 20,
+        "turbine cover naceller bot out (front)": 20,
+        "turbine cover naceller bot in (rear)": 20,
+        "turbine cover naceller bot in (front)": 20,
+        "hardpoint thruster (bottom back right)": 50,
+        "misslerack arm body arm (right)": 1750,
+        "misslerack arm body arm (left)": 1750,
+        "neck": 20000,
+        "nose": 20000,
+        "nose turret door (top right)": 1,
+        "nose turret door (top left)": 1,
+        "nose turret door (bottom right)": 1,
+        "nose turret door (bottom left)": 1,
+        "nose turrethousings": 1,
+        "wing (left)": 15000,
+        "hardpoint thruster vtol 02 (front left)": 50,
+        "hardpoint thruster vtol 01 (front left)": 50,
+        "turbine cover wingl in (top rear)": 20,
+        "turbine cover wingl in (top front)": 20,
+        "turbine cover wingl out (top rear)": 20,
+        "turbine cover wingl out (top front)": 20,
+        "turbine cover wingl bot in (rear)": 20,
+        "turbine cover wingl bot in (front)": 20,
+        "turbine cover wingl bot out (rear)": 20,
+        "turbine cover wingl bot out (front)": 20,
+        "hardpoint thruster center (front left)": 50,
+        "wing (right)": 15000,
+        "hardpoint thruster vtol 02 (front right)": 50,
+        "hardpoint thruster vtol 01 (front right)": 50,
+        "turbine cover wingr bot out (rear)": 20,
+        "turbine cover wingr bot in (front)": 20,
+        "turbine cover wingr out (top front)": 20,
+        "turbine cover wingr out (top rear)": 20,
+        "turbine cover wingr bot out (front)": 20,
+        "turbine cover wingr bot in (rear)": 20,
+        "turbine cover wingr in (top front)": 20,
+        "turbine cover wingr in (top rear)": 20,
+        "hardpoint thruster center (front right)": 50,
+        "hardpoint thruster (top front right)": 50,
+        "hardpoint thruster (top front left)": 50,
+        "hardpoint thruster (bottom front right)": 50,
+        "hardpoint thruster (bottom front left)": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_behr_s03_5ca_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_sasu_s02_daybreak_scitem"
+          },
+          {
+            "class": "powr_sasu_s02_daybreak_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s02_froststarex_scitem"
+          },
+          {
+            "class": "cool_jspn_s02_froststarex_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s02_bolon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "RSI_Constellation_Taurus": {
+      "name": "Constellation Taurus",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": 3256400,
+        "crew": 1,
+        "cargo": 174,
+        "stowage": 5430000,
+        "speed": {
+          "max": 950,
+          "scm": 180,
+          "roll": 45,
+          "pitch": 25,
+          "yaw": 21
+        },
+        "emission": {
+          "ir": 23905,
+          "em_idle": 20850,
+          "em_max": 57715
+        },
+        "fuel": {
+          "quantum": 4.1,
+          "hydro": 66
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s5"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "rsi_constellation_taurus_turret_lower"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "rsi_constellation_scitem_turret_upper"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 24,
+          "missle-class": "misl_s02_cs_thcn_strikeforce"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        },
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        }
+      ],
+      "health": {
+        "rsi constellation taurus": 500,
+        "hardpoint lightgroup": 200,
+        "neck": 20000,
+        "body": 10000,
+        "nacelle (bottom left)": 6500,
+        "hardpoint thruster vtol 02 (rear left)": 50,
+        "hardpoint thruster vtol 01 (rear left)": 50,
+        "turbine cover nacellel in (top rear)": 20,
+        "turbine cover nacellel in (top front)": 20,
+        "turbine cover nacellel out (top rear)": 20,
+        "turbine cover nacellel out (top front)": 20,
+        "turbine cover nacellel bot in (rear)": 20,
+        "turbine cover nacellel bot in (front)": 20,
+        "turbine cover nacellel bot out (rear)": 20,
+        "turbine cover nacellel bot out (front)": 20,
+        "hardpoint thruster (bottom back left)": 50,
+        "nacelle (bottom right)": 6500,
+        "hardpoint thruster vtol 02 (rear right)": 50,
+        "hardpoint thruster vtol 01 (rear right)": 50,
+        "turbine cover naceller out (top rear)": 20,
+        "turbine cover naceller out (top front)": 20,
+        "turbine cover naceller in (top rear)": 20,
+        "turbine cover naceller in (top front)": 20,
+        "turbine cover naceller bot out (rear)": 20,
+        "turbine cover naceller bot out (front)": 20,
+        "turbine cover naceller bot in (rear)": 20,
+        "turbine cover naceller bot in (front)": 20,
+        "hardpoint thruster (bottom back right)": 50,
+        "tail": 20000,
+        "nacelle tower (left)": 1000,
+        "nacelle (left)": 5500,
+        "hardpoint thruster (top back left)": 50,
+        "nacelle tower (right)": 1000,
+        "nacelle (right)": 5500,
+        "hardpoint thruster (top back right)": 50,
+        "hatch (rear)": 1000,
+        "hardpoint thruster center (back left)": 50,
+        "hardpoint thruster center (back right)": 50,
+        "nacelle rail (bottom)": 1000,
+        "nose": 20000,
+        "wing (right)": 15000,
+        "hardpoint thruster vtol 02 (front right)": 50,
+        "hardpoint thruster vtol 01 (front right)": 50,
+        "turbine cover wingr bot out (rear)": 20,
+        "turbine cover wingr bot in (front)": 20,
+        "turbine cover wingr out (top front)": 20,
+        "turbine cover wingr out (top rear)": 20,
+        "turbine cover wingr bot out (front)": 20,
+        "turbine cover wingr bot in (rear)": 20,
+        "turbine cover wingr in (top front)": 20,
+        "turbine cover wingr in (top rear)": 20,
+        "hardpoint thruster center (front right)": 50,
+        "wing (left)": 15000,
+        "hardpoint thruster vtol 02 (front left)": 50,
+        "hardpoint thruster vtol 01 (front left)": 50,
+        "turbine cover wingl in (top rear)": 20,
+        "turbine cover wingl in (top front)": 20,
+        "turbine cover wingl out (top rear)": 20,
+        "turbine cover wingl out (top front)": 20,
+        "turbine cover wingl bot in (rear)": 20,
+        "turbine cover wingl bot in (front)": 20,
+        "turbine cover wingl bot out (rear)": 20,
+        "turbine cover wingl bot out (front)": 20,
+        "hardpoint thruster center (front left)": 50,
+        "nose turret door (top right)": 100,
+        "nose turret door (top left)": 100,
+        "nose turret door (bottom right)": 100,
+        "nose turret door (bottom left)": 100,
+        "hardpoint thruster (bottom front left)": 50,
+        "hardpoint thruster (top front left)": 50,
+        "hardpoint thruster (top front right)": 50,
+        "hardpoint thruster (bottom front right)": 50,
+        "nose turrethousings": 500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s02_diligence_scitem"
+          },
+          {
+            "class": "powr_just_s02_diligence_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s02_coolcore_scitem"
+          },
+          {
+            "class": "cool_just_s02_coolcore_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s02_bolon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "DRAK_Corsair": {
+      "name": "Corsair",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": 3402000,
+        "crew": 4,
+        "cargo": 72,
+        "stowage": 5600000,
+        "speed": {
+          "max": 1025,
+          "scm": 190,
+          "roll": 44,
+          "pitch": 26,
+          "yaw": 20
+        },
+        "emission": {
+          "ir": 22922,
+          "em_idle": 22210,
+          "em_max": 51926
+        },
+        "fuel": {
+          "quantum": 5.2,
+          "hydro": 116
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "drak_corsair_turret_manned"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "drak_corsair_turret_manned"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 8,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Joker Defcon - Decoy Launcher"
+        }
+      ],
+      "health": {
+        "body": 15000,
+        "tail": 15000,
+        "landing gear door slider mesh (right)": 500,
+        "landing gear door rotator mesh (right)": 500,
+        "landing gear door slider mesh (left)": 500,
+        "landing gear door rotator mesh (left)": 500,
+        "nose": 15000,
+        "pitch mesh": 300,
+        "yaw mesh base": 2500,
+        "landing gear door a (front right)": 300,
+        "landing gear door b (front right)": 300,
+        "landing gear door a (front left)": 300,
+        "landing gear door b (front left)": 300,
+        "nacelle mesh (right)": 12500,
+        "wing rotator mesh (right)": 2500,
+        "wing mesh (right)": 5000,
+        "wing bottom flap mesh (right)": 500,
+        "rail door mesh (front)": 500,
+        "rail door mesh (rear)": 500,
+        "wing top flap mesh (right)": 500,
+        "rignt wing tip antenna mesh": 500,
+        "nacelle mesh (left)": 12500,
+        "wing hinge b mesh (bottom)": 2500,
+        "wing hinge mesh (top)": 2500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_behr_s03_5ca_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_sasu_s02_daybreak_scitem"
+          },
+          {
+            "class": "powr_sasu_s02_daybreak_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s02_froststarex_scitem"
+          },
+          {
+            "class": "cool_jspn_s02_froststarex_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_arcc_s02_torrent_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "DRAK_Cutlass_Black": {
+      "name": "Cutlass Black",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": 1385300,
+        "crew": 3,
+        "cargo": 46,
+        "stowage": 3680000,
+        "speed": {
+          "max": 1150,
+          "scm": 217,
+          "roll": 110,
+          "pitch": 39,
+          "yaw": 35
+        },
+        "emission": {
+          "ir": 11059,
+          "em_idle": 8914,
+          "em_max": 33708
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 36
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "drak_cutlass_scitem_turret_black"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 8,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        },
+        {
+          "size": 2,
+          "count": 8,
+          "missle-class": "misl_s02_cs_fski_tempest"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 6500,
+        "tail": 6500,
+        "missile housing (left)": 900,
+        "missile housing (right)": 900,
+        "thruster main base (right)": 480,
+        "thruster main (right)": 5000,
+        "thruster main base (left)": 480,
+        "thruster main (left)": 5000,
+        "canopy": 1000,
+        "wing (right)": 1500,
+        "wing (left)": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s02_stop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_sasu_s02_daybreak_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_lplt_s02_coldsnap_scitem"
+          },
+          {
+            "class": "cool_lplt_s02_coldsnap_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s02_odyssey_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Vantage Rentals, CRU-L1",
+        "Vantage Rentals, ARC-L1",
+        "Vantage Rentals, HUR-L1",
+        "Vantage Rentals, HUR-L2",
+        "Vantage Rentals, MIC-L2",
+        "Traveler Rentals, Port Tressler",
+        "Traveler Rentals, Everus Harbor",
+        "Traveler Rentals, Baijini Point"
+      ]
+    },
+    "DRAK_Cutlass_Blue": {
+      "name": "Cutlass Blue",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": 2493500,
+        "crew": 3,
+        "cargo": 12,
+        "stowage": 2780000,
+        "speed": {
+          "max": 1165,
+          "scm": 220,
+          "roll": 110,
+          "pitch": 38,
+          "yaw": 34
+        },
+        "emission": {
+          "ir": 10574,
+          "em_idle": 11373,
+          "em_max": 40967
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 36
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "asad_distortionrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "asad_distortionrepeater_s3"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "drak_cutlass_scitem_turret_blue"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 24,
+          "missle-class": "misl_s02_cs_fski_tempest"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 6500,
+        "tail": 6500,
+        "missile housing (right)": 900,
+        "missile housing (left)": 900,
+        "thruster main base (right)": 480,
+        "thruster main (right)": 5000,
+        "thruster main base (left)": 480,
+        "thruster main (left)": 5000,
+        "canopy": 6250,
+        "wing (left)": 1880,
+        "wing (right)": 1880
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s02_aspis_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_amrs_s02_turbodrive_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_wcpr_s02_graupel_scitem"
+          },
+          {
+            "class": "cool_wcpr_s02_graupel_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s02_bolon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "DRAK_Cutlass_Red": {
+      "name": "Cutlass Red",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": 1810500,
+        "crew": 2,
+        "cargo": 12,
+        "stowage": 3430000,
+        "speed": {
+          "max": 1125,
+          "scm": 212,
+          "roll": 107,
+          "pitch": 37,
+          "yaw": 32
+        },
+        "emission": {
+          "ir": 9359,
+          "em_idle": 7913,
+          "em_max": 36226
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 36
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "drak_cutlass_red_sensor_turret_s4"
+        }
+      ],
+      "missles": [],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 6600,
+        "tail": 6600,
+        "thruster main base (right)": 480,
+        "thruster main (right)": 5200,
+        "thruster main base (left)": 480,
+        "thruster main (left)": 5200,
+        "canopy": 6200,
+        "wing (left)": 1880,
+        "wing (right)": 1880
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s02_aspis_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s02_diligence_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s02_coolcore_scitem"
+          },
+          {
+            "class": "cool_just_s02_coolcore_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s02_bolon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "DRAK_Cutlass_Steel": {
+      "name": "Cutlass Steel",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": 1355300,
+        "crew": 3,
+        "cargo": 0,
+        "stowage": 2780000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 11079,
+          "em_idle": 9443,
+          "em_max": 36031
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "drak_cutlass_scitem_turret_black"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 8,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        },
+        {
+          "size": 2,
+          "count": 8,
+          "missle-class": "misl_s02_cs_fski_tempest"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 9400,
+        "tail": 6500,
+        "missile housing (left)": 900,
+        "missile housing (right)": 900,
+        "thruster main base (right)": 480,
+        "thruster main (right)": 5000,
+        "thruster main base (left)": 480,
+        "thruster main (left)": 5000,
+        "canopy": 1000,
+        "wing (right)": 1500,
+        "wing (left)": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_amrs_s02_turbodrive_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          },
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s02_crossfield_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "DRAK_Cutter": {
+      "name": "Cutter",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 675000,
+        "crew": 1,
+        "cargo": 4,
+        "stowage": 930000,
+        "speed": {
+          "max": 1010,
+          "scm": 180,
+          "roll": 100,
+          "pitch": 36,
+          "yaw": 36
+        },
+        "emission": {
+          "ir": 8691,
+          "em_idle": 2067,
+          "em_max": 15489
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 12
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 4,
+          "missle-class": "misl_s01_cs_fski_spark"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 6500,
+        "vtol l geo": 3000,
+        "nose": 3000,
+        "debrisproxy spoiler (right)": 50,
+        "debrisproxy spoiler (left)": 50,
+        "vtol r geo": 3000,
+        "body armour (top)": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s01_hex_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_sasu_s01_lightblossom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_lplt_s01_blastchill_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_acas_s01_foxfire_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "DRAK_Cutter_Rambler": {
+      "name": "Cutter Rambler",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 2,
+        "stowage": 4000000,
+        "speed": {
+          "max": 1010,
+          "scm": 180,
+          "roll": 100,
+          "pitch": 36,
+          "yaw": 36
+        },
+        "emission": {
+          "ir": 8691,
+          "em_idle": 2067,
+          "em_max": 15489
+        },
+        "fuel": {
+          "quantum": 2.2,
+          "hydro": 24
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 4,
+          "missle-class": "misl_s01_cs_fski_spark"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 6500,
+        "vtol l geo": 3000,
+        "nose": 3000,
+        "debrisproxy spoiler (right)": 50,
+        "debrisproxy spoiler (left)": 50,
+        "vtol r geo": 3000,
+        "body armour (top)": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s01_hex_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_sasu_s01_lightblossom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_lplt_s01_blastchill_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_acas_s01_foxfire_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "DRAK_Cutter_Scout": {
+      "name": "Cutter Scout",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 2,
+        "stowage": 930000,
+        "speed": {
+          "max": 1010,
+          "scm": 180,
+          "roll": 100,
+          "pitch": 36,
+          "yaw": 36
+        },
+        "emission": {
+          "ir": 9130,
+          "em_idle": 2161,
+          "em_max": 19175
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 12
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 2,
+          "missle-class": "misl_s02_cs_fski_tempest"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 6700,
+        "vtol l geo": 3000,
+        "nose": 3200,
+        "debrisproxy spoiler (right)": 50,
+        "debrisproxy spoiler (left)": 50,
+        "vtol r geo": 3000,
+        "body armour (top)": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s01_hex_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_amrs_s02_exogen_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s02_boreal_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_acas_s01_foxfire_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "TMBL_Cyclone": {
+      "name": "Cyclone",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": 26500,
+        "crew": 1,
+        "cargo": 1,
+        "stowage": 4130000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 1155,
+          "em_idle": 2806,
+          "em_max": 15030
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "tmbl cyclone": 1500,
+        "wheelfr": 800,
+        "wheelfl": 800,
+        "wheelbr": 800,
+        "wheelbl": 800,
+        "body": 2000,
+        "hood": 1,
+        "armor plating right (rear)": 50,
+        "mud flap br": 25,
+        "mud flap fr": 25,
+        "mud flap fl": 25,
+        "armor plating left (rear)": 50,
+        "mud flap bl": 25,
+        "body decals": 1,
+        "$lod5 body decals": 1,
+        "$lod4 body decals": 1,
+        "$lod3 body decals": 1,
+        "$lod2 body decals": 1,
+        "$lod1 body decals": 1,
+        "livery decal": 1,
+        "$lod2 livery decal": 1,
+        "$lod1 livery decal": 1
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Traveler Rentals, Area 18",
+        "Traveler Rentals, Orison",
+        "Vantage Rentals, Lorville"
+      ]
+    },
+    "TMBL_Cyclone_AA": {
+      "name": "Cyclone AA",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": 26500,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 3520000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 1855,
+          "em_idle": 4306,
+          "em_max": 17530
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "tmbl cyclone": 1500,
+        "wheelfr": 800,
+        "wheelfl": 800,
+        "wheelbr": 800,
+        "wheelbl": 800,
+        "body": 2000,
+        "hood": 1,
+        "armor plating right (rear)": 50,
+        "mud flap br": 25,
+        "mud flap fr": 25,
+        "mud flap fl": 25,
+        "armor plating left (rear)": 50,
+        "mud flap bl": 25,
+        "body decals": 1,
+        "$lod5 body decals": 1,
+        "$lod4 body decals": 1,
+        "$lod3 body decals": 1,
+        "$lod2 body decals": 1,
+        "$lod1 body decals": 1,
+        "livery decal": 1,
+        "$lod2 livery decal": 1,
+        "$lod1 livery decal": 1
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "TMBL_Cyclone_MT": {
+      "name": "Cyclone MT",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": 26500,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 3520000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 1280,
+          "em_idle": 3113,
+          "em_max": 15343
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "kbar_ballisticcannon_s1"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "tmbl_cyclone_module_mt"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "tmbl cyclone": 1500,
+        "wheelfr": 800,
+        "wheelfl": 800,
+        "wheelbr": 800,
+        "wheelbl": 800,
+        "body": 2000,
+        "hood": 1,
+        "armor plating right (rear)": 50,
+        "mud flap br": 25,
+        "mud flap fr": 25,
+        "mud flap fl": 25,
+        "armor plating left (rear)": 50,
+        "mud flap bl": 25,
+        "body decals": 1,
+        "$lod5 body decals": 1,
+        "$lod4 body decals": 1,
+        "$lod3 body decals": 1,
+        "$lod2 body decals": 1,
+        "$lod1 body decals": 1,
+        "livery decal": 1,
+        "$lod2 livery decal": 1,
+        "$lod1 livery decal": 1
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "TMBL_Cyclone_RC": {
+      "name": "Cyclone RC",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": 26500,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 3520000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 1155,
+          "em_idle": 2806,
+          "em_max": 15030
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "tmbl cyclone": 1500,
+        "wheelfr": 800,
+        "wheelfl": 800,
+        "wheelbr": 800,
+        "wheelbl": 800,
+        "body": 2000,
+        "hood": 1,
+        "armor plating right (rear)": 50,
+        "mud flap br": 25,
+        "mud flap fr": 25,
+        "mud flap fl": 25,
+        "armor plating left (rear)": 50,
+        "mud flap bl": 25,
+        "body decals": 1,
+        "$lod5 body decals": 1,
+        "$lod4 body decals": 1,
+        "$lod3 body decals": 1,
+        "$lod2 body decals": 1,
+        "$lod1 body decals": 1,
+        "livery decal": 1,
+        "$lod2 livery decal": 1,
+        "$lod1 livery decal": 1
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "TMBL_Cyclone_RN": {
+      "name": "Cyclone RN",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": 26500,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 3950000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 1155,
+          "em_idle": 2806,
+          "em_max": 15030
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "tmbl cyclone": 1500,
+        "wheelfr": 800,
+        "wheelfl": 800,
+        "wheelbr": 800,
+        "wheelbl": 800,
+        "body": 2000,
+        "hood": 1,
+        "armor plating right (rear)": 50,
+        "mud flap br": 25,
+        "mud flap fr": 25,
+        "mud flap fl": 25,
+        "armor plating left (rear)": 50,
+        "mud flap bl": 25,
+        "body decals": 1,
+        "$lod5 body decals": 1,
+        "$lod4 body decals": 1,
+        "$lod3 body decals": 1,
+        "$lod2 body decals": 1,
+        "$lod1 body decals": 1,
+        "livery decal": 1,
+        "$lod2 livery decal": 1,
+        "$lod1 livery decal": 1
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "TMBL_Cyclone_TR": {
+      "name": "Cyclone TR",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": 26500,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 3520000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 1161,
+          "em_idle": 2821,
+          "em_max": 15050
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s1"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "tmbl_cyclone_module_turret"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "tmbl cyclone": 1500,
+        "wheelfr": 800,
+        "wheelfl": 800,
+        "wheelbr": 800,
+        "wheelbl": 800,
+        "body": 2000,
+        "hood": 1,
+        "armor plating right (rear)": 50,
+        "mud flap br": 25,
+        "mud flap fr": 25,
+        "mud flap fl": 25,
+        "armor plating left (rear)": 50,
+        "mud flap bl": 25,
+        "body decals": 1,
+        "$lod5 body decals": 1,
+        "$lod4 body decals": 1,
+        "$lod3 body decals": 1,
+        "$lod2 body decals": 1,
+        "$lod1 body decals": 1,
+        "livery decal": 1,
+        "$lod2 livery decal": 1,
+        "$lod1 livery decal": 1
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "BANU_Defender": {
+      "name": "Defender",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 2781000,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1420000,
+        "speed": {
+          "max": 1175,
+          "scm": 222,
+          "roll": 170,
+          "pitch": 61,
+          "yaw": 61
+        },
+        "emission": {
+          "ir": 8696,
+          "em_idle": 12704,
+          "em_max": 29564
+        },
+        "fuel": {
+          "quantum": 3.1,
+          "hydro": 43
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "banu_tachyoncannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "banu_tachyoncannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "banu_tachyoncannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "banu_tachyoncannon_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 6,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 3500,
+        "body panels 02": 200,
+        "canopy (right)": 50,
+        "canopy (left)": 50,
+        "wing hull (right)": 3000,
+        "wing hull (left)": 3000,
+        "pod": 4000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_banu_s02_placeholder_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s01_ionburst_scitem"
+          },
+          {
+            "class": "powr_lplt_s01_ionburst_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s01_beacon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "DRAK_Dragonfly": {
+      "name": "Dragonfly Black",
+      "stats": {
+        "ship-size": "snub",
+        "purchase-price": 272700,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1170000,
+        "speed": {
+          "max": 523,
+          "scm": 190,
+          "roll": 130,
+          "pitch": 70,
+          "yaw": 70
+        },
+        "emission": {
+          "ir": 2229,
+          "em_idle": 2774,
+          "em_max": 15475
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 1.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticscattergun_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticscattergun_s1"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "nacelle main (rear right)": 160,
+        "hardpoint thruster (rear top right)": 50,
+        "hardpoint thruster (rear bottom right)": 50,
+        "nacelle main (rear left)": 160,
+        "hardpoint thruster (rear bottom left)": 50,
+        "hardpoint thruster (rear top left)": 50,
+        "nacelle main (front left)": 160,
+        "hardpoint thruster (front bottom left)": 50,
+        "hardpoint thruster (front top left)": 50,
+        "hardpoint retro (left)": 50,
+        "nacelle main (front right)": 160,
+        "hardpoint thruster (front bottom right)": 50,
+        "hardpoint thruster (front top right)": 50,
+        "hardpoint retro (right)": 50,
+        "nose": 880,
+        "body": 50,
+        "hardpoint engine": 50
+      },
+      "components": {
+        "shields": [],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_wcpr_s00_fridan_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Traveler Rentals, Area 18",
+        "Traveler Rentals, Orison",
+        "Vantage Rentals, Lorville"
+      ]
+    },
+    "DRAK_Dragonfly_Yellow": {
+      "name": "Dragonfly Yellowjacket",
+      "stats": {
+        "ship-size": "snub",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1170000,
+        "speed": {
+          "max": 523,
+          "scm": 190,
+          "roll": 130,
+          "pitch": 70,
+          "yaw": 70
+        },
+        "emission": {
+          "ir": 2229,
+          "em_idle": 2774,
+          "em_max": 15475
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 1.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticscattergun_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticscattergun_s1"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "nacelle main (rear right)": 160,
+        "hardpoint thruster (rear top right)": 50,
+        "hardpoint thruster (rear bottom right)": 50,
+        "nacelle main (rear left)": 160,
+        "hardpoint thruster (rear bottom left)": 50,
+        "hardpoint thruster (rear top left)": 50,
+        "nacelle main (front left)": 160,
+        "hardpoint thruster (front bottom left)": 50,
+        "hardpoint thruster (front top left)": 50,
+        "hardpoint retro (left)": 50,
+        "nacelle main (front right)": 160,
+        "hardpoint thruster (front bottom right)": 50,
+        "hardpoint thruster (front top right)": 50,
+        "hardpoint retro (right)": 50,
+        "nose": 880,
+        "body": 50,
+        "hardpoint engine": 50
+      },
+      "components": {
+        "shields": [],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_wcpr_s00_fridan_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "AEGS_Eclipse": {
+      "name": "Eclipse",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": 3490000,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1300000,
+        "speed": {
+          "max": 1100,
+          "scm": 210,
+          "roll": 115,
+          "pitch": 38,
+          "yaw": 31
+        },
+        "emission": {
+          "ir": 6910,
+          "em_idle": 6453,
+          "em_max": 20599
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 9
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [
+        {
+          "size": 9,
+          "count": 3,
+          "missle-class": "misl_s09_cs_taln_argos"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 10000,
+        "bay door r a": 1,
+        "bay door r b": 1,
+        "bay door l a": 1,
+        "bay door l b": 1,
+        "tail": 1500,
+        "hardpoint engine (right)": 10,
+        "hardpoint engine (left)": 10,
+        "hardpoint thruster rr (bottom)": 50,
+        "hardpoint thruster rl (bottom)": 50,
+        "hardpoint thruster rr (top)": 50,
+        "hardpoint thruster rl (top)": 50,
+        "wing (right)": 1500,
+        "wing broken (right)": 320,
+        "wingtip (right)": 200,
+        "hardpoint thruster fr (top)": 50,
+        "hardpoint thruster retro (right)": 50,
+        "hardpoint thruster fr (bottom)": 50,
+        "wing (left)": 1500,
+        "wing broken (left)": 320,
+        "wingtip (left)": 200,
+        "hardpoint thruster fl (bottom)": 50,
+        "hardpoint thruster retro (left)": 50,
+        "hardpoint thruster fl (top)": 50,
+        "nose": 10000,
+        "cockpit canopy": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_veil_scitem"
+          },
+          {
+            "class": "shld_asas_s01_veil_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_tydt_s01_deltamax_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_tydt_s01_vaporblock_scitem"
+          },
+          {
+            "class": "cool_tydt_s01_vaporblock_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_raco_s01_drift_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "ANVL_Hornet_F7A_Mk1": {
+      "name": "F7A Hornet Mk I",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1300000,
+        "speed": {
+          "max": 1146,
+          "scm": 220,
+          "roll": 147,
+          "pitch": 53,
+          "yaw": 42
+        },
+        "emission": {
+          "ir": 6587,
+          "em_idle": 6328,
+          "em_max": 24460
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 14
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_ballisticgatling_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_ballisticgatling_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_em_taln_dominator"
+        },
+        {
+          "size": 1,
+          "count": 8,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 2750,
+        "wing (rightrear)": 700,
+        "wing (leftrear)": 700,
+        "wing (right)": 200,
+        "wingdebris (right)": 1500,
+        "wing (left)": 200,
+        "wingdebris (left)": 1500,
+        "wingdebris livery decal (left)": 1,
+        "$lod5 wingdebris livery decal (left)": 1,
+        "$lod4 wingdebris livery decal (left)": 1,
+        "$lod3 wingdebris livery decal (left)": 1,
+        "$lod2 wingdebris livery decal (left)": 1,
+        "$lod1 wingdebris livery decal (left)": 1,
+        "nose": 2750,
+        "canopy": 200,
+        "tail": 1800,
+        "debris (tail)": 1500,
+        "livery decal left (tail)": 200,
+        "$lod5 livery decal left (tail)": 200,
+        "$lod4 livery decal left (tail)": 200,
+        "$lod3 livery decal left (tail)": 200,
+        "$lod1 livery decal left (tail)": 200,
+        "$lod2 livery decal left (tail)": 200,
+        "livery decal right (tail)": 200,
+        "$lod5 livery decal right (tail)": 200,
+        "$lod4 livery decal right (tail)": 200,
+        "$lod3 livery decal right (tail)": 200,
+        "$lod2 livery decal right (tail)": 200,
+        "$lod1 livery decal right (tail)": 200,
+        "enginehousing": 400,
+        "thrust vector flap a": 50,
+        "thrust vector flap b": 50,
+        "thrust vector flap c": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s01_web_scitem"
+          },
+          {
+            "class": "shld_seco_s01_web_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_amrs_s02_turbodrive_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_lplt_s01_arcticstorm_scitem"
+          },
+          {
+            "class": "cool_lplt_s01_arcticstorm_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ANVL_Hornet_F7A_Mk2": {
+      "name": "F7A Hornet Mk II",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 650000,
+        "speed": {
+          "max": 1146,
+          "scm": 220,
+          "roll": 143,
+          "pitch": 50,
+          "yaw": 40
+        },
+        "emission": {
+          "ir": 7837,
+          "em_idle": 6944,
+          "em_max": 25611
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 16
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticgatling_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticgatling_s4"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 8,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 3000,
+        "cap spine": 250,
+        "wing (left)": 200,
+        "wing debris (left)": 1600,
+        "hardpoint weapon wing (left)": 650,
+        "wing debris 02 (left)": 200,
+        "tail": 1900,
+        "wing (tail)": 1,
+        "wing debris (tail)": 400,
+        "thrust vector flap c": 50,
+        "thrust vector flap b": 50,
+        "thrust vector flap a": 50,
+        "nose": 3000,
+        "canopy": 200,
+        "small wing (right)": 100,
+        "small wing flap (right)": 50,
+        "small wing (left)": 100,
+        "small wing flap (left)": 50,
+        "wing (right)": 200,
+        "wing debris (right)": 1600,
+        "wing flap (right)": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          },
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ANVL_Hornet_F7C": {
+      "name": "F7C Hornet Mk I",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1492700,
+        "crew": 1,
+        "cargo": 2,
+        "stowage": 1300000,
+        "speed": {
+          "max": 1150,
+          "scm": 220,
+          "roll": 149,
+          "pitch": 55,
+          "yaw": 44
+        },
+        "emission": {
+          "ir": 5458,
+          "em_idle": 5413,
+          "em_max": 19653
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 12
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_em_taln_dominator"
+        },
+        {
+          "size": 1,
+          "count": 4,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Anvil Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Anvil Noise Launcher"
+        }
+      ],
+      "health": {
+        "wingdebris (left)": 1500,
+        "wingdebris (right)": 1500,
+        "lg door l (rear)": 100,
+        "lg door r (rear)": 100,
+        "body": 2650,
+        "tail": 1800,
+        "debris (tail)": 1500,
+        "wing (leftrear)": 700,
+        "wing (rightrear)": 700,
+        "nose": 2650,
+        "canopy": 200,
+        "intake (right)": 400,
+        "missilebay (right)": 400,
+        "enginehousing": 400,
+        "thrust vector flap b": 50,
+        "thrust vector flap a": 50,
+        "thrust vector flap c": 50,
+        "intake (left)": 400,
+        "missilebay (left)": 400
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s01_web_scitem"
+          },
+          {
+            "class": "shld_seco_s01_web_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s01_powerbolt_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_lplt_s01_arcticstorm_scitem"
+          },
+          {
+            "class": "cool_lplt_s01_arcticstorm_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ANVL_Hornet_F7C_Mk2": {
+      "name": "F7C Hornet Mk II",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 650000,
+        "speed": {
+          "max": 1150,
+          "scm": 220,
+          "roll": 148,
+          "pitch": 52,
+          "yaw": 43
+        },
+        "emission": {
+          "ir": 6988,
+          "em_idle": 5196,
+          "em_max": 23739
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 16
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticgatling_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticgatling_s4"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 8,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 2850,
+        "cap spine": 250,
+        "wing (left)": 200,
+        "wing debris (left)": 1600,
+        "hardpoint weapon wing (left)": 650,
+        "wing debris 02 (left)": 200,
+        "tail": 1900,
+        "wing (tail)": 1,
+        "wing debris (tail)": 400,
+        "thrust vector flap c": 50,
+        "thrust vector flap b": 50,
+        "thrust vector flap a": 50,
+        "nose": 2850,
+        "canopy": 200,
+        "small wing (right)": 100,
+        "small wing flap (right)": 50,
+        "small wing (left)": 100,
+        "small wing flap (left)": 50,
+        "wing (right)": 200,
+        "wing debris (right)": 1600,
+        "wing flap (right)": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          },
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          },
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ANVL_Hornet_F7C_Wildfire": {
+      "name": "F7C Hornet Wildfire Mk I",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 2246100,
+        "crew": 1,
+        "cargo": 2,
+        "stowage": 1300000,
+        "speed": {
+          "max": 1150,
+          "scm": 220,
+          "roll": 149,
+          "pitch": 55,
+          "yaw": 44
+        },
+        "emission": {
+          "ir": 6118,
+          "em_idle": 5084,
+          "em_max": 20859
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 12
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticcannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticcannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticgatling_s4"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_em_taln_dominator"
+        },
+        {
+          "size": 1,
+          "count": 4,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Anvil Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Anvil Noise Launcher"
+        }
+      ],
+      "health": {
+        "wingdebris (left)": 1500,
+        "wingdebris (right)": 1500,
+        "lg door l (rear)": 100,
+        "lg door r (rear)": 100,
+        "body": 2650,
+        "tail": 1800,
+        "debris (tail)": 1500,
+        "wing (leftrear)": 700,
+        "wing (rightrear)": 700,
+        "nose": 2650,
+        "canopy": 200,
+        "intake (right)": 400,
+        "missilebay (right)": 400,
+        "enginehousing": 400,
+        "thrust vector flap b": 50,
+        "thrust vector flap a": 50,
+        "thrust vector flap c": 50,
+        "intake (left)": 400,
+        "missilebay (left)": 400
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s01_web_scitem"
+          },
+          {
+            "class": "shld_seco_s01_web_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s01_roughneck_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_lplt_s01_arcticstorm_scitem"
+          },
+          {
+            "class": "cool_lplt_s01_arcticstorm_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ANVL_Hornet_F7CM_Heartseeker": {
+      "name": "F7C-M Super Hornet Heartseeker Mk I",
+      "stats": {
+        "ship-size": "",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 2580000,
+        "speed": {
+          "max": 1142,
+          "scm": 219,
+          "roll": 145,
+          "pitch": 53,
+          "yaw": 42
+        },
+        "emission": {
+          "ir": 6003,
+          "em_idle": 5375,
+          "em_max": 20418
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 13.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_ir_novp_rattler"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Anvil Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Anvil Noise Launcher"
+        }
+      ],
+      "health": {
+        "wingdebris (right)": 1500,
+        "lg door r (rear)": 100,
+        "wingdebris (left)": 1500,
+        "lg door l (rear)": 100,
+        "body": 2900,
+        "intake (right)": 400,
+        "wing (rightrear)": 700,
+        "nose": 2900,
+        "canopy (rear)": 200,
+        "canopy": 200,
+        "intake (left)": 400,
+        "wing (leftrear)": 700,
+        "tail": 1800,
+        "debris (tail)": 1500,
+        "enginehousing": 400,
+        "thrust vector flap a": 50,
+        "thrust vector flap b": 50,
+        "thrust vector flap c": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_forcewall_scitem"
+          },
+          {
+            "class": "shld_godi_s01_forcewall_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_amrs_s01_overdrive_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": true,
+      "shops": []
+    },
+    "ANVL_Hornet_F7CM_Mk2_Heartseeker": {
+      "name": "F7C-M Super Hornet Heartseeker Mk II",
+      "stats": {
+        "ship-size": "",
+        "purchase-price": null,
+        "crew": 2,
+        "cargo": 0,
+        "stowage": 1290000,
+        "speed": {
+          "max": 1125,
+          "scm": 215,
+          "roll": 140,
+          "pitch": 50,
+          "yaw": 40
+        },
+        "emission": {
+          "ir": 7682,
+          "em_idle": 6417,
+          "em_max": 25234
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 16
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticgatling_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticgatling_s4"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 8,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 3150,
+        "wing (left)": 300,
+        "wing debris (left)": 1600,
+        "wing flap (left)": 50,
+        "nose": 3150,
+        "canopy pilot": 200,
+        "canopy copilot": 200,
+        "nacelle (right)": 200,
+        "nacelle (left)": 200,
+        "geo (tail)": 1900,
+        "wing debris (tail)": 1600,
+        "thrust vector flap c": 50,
+        "thrust vector flap b": 50,
+        "thrust vector flap a": 50,
+        "small wing (right)": 150,
+        "small wing flap (right)": 150,
+        "small wing (left)": 150,
+        "small wing flap (left)": 150,
+        "wing (right)": 300,
+        "wing debris (right)": 1600,
+        "wing flap (right)": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          },
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          },
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": true,
+      "shops": []
+    },
+    "ANVL_Hornet_F7CM": {
+      "name": "F7C-M Super Hornet Mk I",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 2132600,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 2580000,
+        "speed": {
+          "max": 1142,
+          "scm": 219,
+          "roll": 145,
+          "pitch": 53,
+          "yaw": 42
+        },
+        "emission": {
+          "ir": 6183,
+          "em_idle": 5495,
+          "em_max": 21007
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 13.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 8,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Anvil Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Anvil Noise Launcher"
+        }
+      ],
+      "health": {
+        "wingdebris (right)": 1500,
+        "lg door r (rear)": 100,
+        "wingdebris (left)": 1500,
+        "lg door l (rear)": 100,
+        "body": 2900,
+        "intake (right)": 400,
+        "wing (rightrear)": 700,
+        "nose": 2900,
+        "canopy (rear)": 200,
+        "canopy": 200,
+        "intake (left)": 400,
+        "wing (leftrear)": 700,
+        "tail": 1800,
+        "debris (tail)": 1500,
+        "enginehousing": 400,
+        "thrust vector flap a": 50,
+        "thrust vector flap b": 50,
+        "thrust vector flap c": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          },
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ANVL_Hornet_F7CM_Mk2": {
+      "name": "F7C-M Super Hornet Mk II",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 2,
+        "cargo": 0,
+        "stowage": 1290000,
+        "speed": {
+          "max": 1125,
+          "scm": 215,
+          "roll": 140,
+          "pitch": 50,
+          "yaw": 40
+        },
+        "emission": {
+          "ir": 7932,
+          "em_idle": 7077,
+          "em_max": 25894
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 16
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticgatling_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticgatling_s4"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 8,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 3150,
+        "wing (left)": 300,
+        "wing debris (left)": 1600,
+        "wing flap (left)": 50,
+        "nose": 3150,
+        "canopy pilot": 200,
+        "canopy copilot": 200,
+        "nacelle (right)": 200,
+        "nacelle (left)": 200,
+        "geo (tail)": 1900,
+        "wing debris (tail)": 1600,
+        "thrust vector flap c": 50,
+        "thrust vector flap b": 50,
+        "thrust vector flap a": 50,
+        "small wing (right)": 150,
+        "small wing flap (right)": 150,
+        "small wing (left)": 150,
+        "small wing flap (left)": 150,
+        "wing (right)": 300,
+        "wing debris (right)": 1600,
+        "wing flap (right)": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          },
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          },
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ANVL_Hornet_F7CR": {
+      "name": "F7C-R Hornet Tracker Mk I",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1832100,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1300000,
+        "speed": {
+          "max": 1142,
+          "scm": 219,
+          "roll": 150,
+          "pitch": 56,
+          "yaw": 45
+        },
+        "emission": {
+          "ir": 5858,
+          "em_idle": 5698,
+          "em_max": 19538
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 12
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_em_taln_dominator"
+        },
+        {
+          "size": 1,
+          "count": 4,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Anvil Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Anvil Noise Launcher"
+        }
+      ],
+      "health": {
+        "wingdebris (left)": 1500,
+        "wingdebris (right)": 1500,
+        "lg door l (rear)": 100,
+        "lg door r (rear)": 100,
+        "body": 2650,
+        "tail": 1800,
+        "debris (tail)": 1500,
+        "wing (leftrear)": 700,
+        "wing (rightrear)": 700,
+        "nose": 2650,
+        "canopy": 200,
+        "intake (right)": 400,
+        "missilebay (right)": 400,
+        "enginehousing": 400,
+        "thrust vector flap b": 50,
+        "thrust vector flap a": 50,
+        "thrust vector flap c": 50,
+        "intake (left)": 400,
+        "missilebay (left)": 400
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_yorm_s01_targa_scitem"
+          },
+          {
+            "class": "shld_yorm_s01_targa_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_acom_s01_lumacore_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_acom_s01_iceplunge_scitem"
+          },
+          {
+            "class": "cool_acom_s01_iceplunge_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ANVL_Hornet_F7CR_Mk2": {
+      "name": "F7C-R Hornet Tracker Mk II",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 650000,
+        "speed": {
+          "max": 1150,
+          "scm": 220,
+          "roll": 148,
+          "pitch": 52,
+          "yaw": 43
+        },
+        "emission": {
+          "ir": 7288,
+          "em_idle": 5196,
+          "em_max": 23739
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 14.4
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticgatling_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticgatling_s4"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 8,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 2850,
+        "cap spine": 250,
+        "wing (left)": 200,
+        "wing debris (left)": 1600,
+        "hardpoint weapon wing (left)": 650,
+        "wing debris 02 (left)": 200,
+        "tail": 1900,
+        "wing (tail)": 1,
+        "wing debris (tail)": 400,
+        "thrust vector flap c": 50,
+        "thrust vector flap b": 50,
+        "thrust vector flap a": 50,
+        "nose": 2850,
+        "canopy": 200,
+        "small wing (right)": 100,
+        "small wing flap (right)": 50,
+        "small wing (left)": 100,
+        "small wing flap (left)": 50,
+        "wing (right)": 200,
+        "wing debris (right)": 1600,
+        "wing flap (right)": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          },
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          },
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ANVL_Hornet_F7CS": {
+      "name": "F7C-S Hornet Ghost Mk I",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1654100,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1300000,
+        "speed": {
+          "max": 1142,
+          "scm": 219,
+          "roll": 149,
+          "pitch": 55,
+          "yaw": 44
+        },
+        "emission": {
+          "ir": 5758,
+          "em_idle": 5677,
+          "em_max": 19717
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 12
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        },
+        {
+          "size": 1,
+          "count": 4,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Anvil Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Anvil Noise Launcher"
+        }
+      ],
+      "health": {
+        "wingdebris (left)": 1500,
+        "wingdebris (right)": 1500,
+        "lg door l (rear)": 100,
+        "lg door r (rear)": 100,
+        "body": 2550,
+        "tail": 1800,
+        "debris (tail)": 1500,
+        "wing (leftrear)": 700,
+        "wing (rightrear)": 700,
+        "nose": 2550,
+        "canopy": 200,
+        "intake (right)": 400,
+        "missilebay (right)": 400,
+        "enginehousing": 400,
+        "thrust vector flap b": 50,
+        "thrust vector flap a": 50,
+        "thrust vector flap c": 50,
+        "intake (left)": 400,
+        "missilebay (left)": 400
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          },
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_tydt_s01_slipstream_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_tydt_s01_heatsafe_scitem"
+          },
+          {
+            "class": "cool_tydt_s01_heatsafe_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ANVL_Hornet_F7CS_Mk2": {
+      "name": "F7C-S Hornet Ghost Mk II",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 650000,
+        "speed": {
+          "max": 1150,
+          "scm": 220,
+          "roll": 147,
+          "pitch": 51,
+          "yaw": 42
+        },
+        "emission": {
+          "ir": 7208,
+          "em_idle": 5196,
+          "em_max": 20400
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 14.4
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticgatling_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticgatling_s4"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 8,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 2750,
+        "cap spine": 250,
+        "wing (left)": 200,
+        "wing debris (left)": 1600,
+        "hardpoint weapon wing (left)": 650,
+        "wing debris 02 (left)": 200,
+        "tail": 1900,
+        "wing (tail)": 1,
+        "wing debris (tail)": 400,
+        "thrust vector flap c": 50,
+        "thrust vector flap b": 50,
+        "thrust vector flap a": 50,
+        "nose": 2750,
+        "canopy": 200,
+        "small wing (right)": 100,
+        "small wing flap (right)": 50,
+        "small wing (left)": 100,
+        "small wing flap (left)": 50,
+        "wing (right)": 200,
+        "wing debris (right)": 1600,
+        "wing flap (right)": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          },
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_tydt_s01_soniclite_scitem"
+          },
+          {
+            "class": "powr_tydt_s01_soniclite_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_tydt_s01_heatsafe_scitem"
+          },
+          {
+            "class": "cool_tydt_s01_heatsafe_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_raco_s01_drift_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ANVL_Lightning_F8C": {
+      "name": "F8C Lightning",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1300000,
+        "speed": {
+          "max": 1075,
+          "scm": 207,
+          "roll": 120,
+          "pitch": 38,
+          "yaw": 35
+        },
+        "emission": {
+          "ir": 9826,
+          "em_idle": 7683,
+          "em_max": 27197
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 37.2
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticcannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticcannon_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticcannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticcannon_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 8,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Anvil Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Anvil Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 9200,
+        "wing right (front)": 500,
+        "wing left (front)": 500,
+        "nose": 7650,
+        "canopy": 350,
+        "tail left": 250,
+        "tail right": 250,
+        "hardpoint thruster rr (top)": 10,
+        "wing base (right)": 6000,
+        "wing flap right (top)": 250,
+        "fin bot (right)": 500,
+        "fin (top right)": 500,
+        "wing (right)": 500,
+        "weapon mount wing a s4 (right)": 200,
+        "weapon mount wing b s3 (right)": 200,
+        "mini wing (right)": 250,
+        "wing right (rear)": 2000,
+        "wing flap right (rear)": 250,
+        "engine center": 200,
+        "hardpoint engine mid": 10,
+        "wing base (left)": 6000,
+        "wing flap left (top)": 250,
+        "fin (top left)": 500,
+        "fin bot (left)": 500,
+        "wing (left)": 500,
+        "weapon mount wing a s4 (left)": 200,
+        "weapon mount wing b s3 (left)": 200,
+        "mini wing (left)": 250,
+        "wing left (rear)": 2000,
+        "wing flap left (rear)": 250
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s02_sheut_scitem"
+          },
+          {
+            "class": "shld_asas_s02_sheut_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s01_expedition_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ANVL_Lightning_F8C_Exec": {
+      "name": "F8C Lightning Executive Edition",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1300000,
+        "speed": {
+          "max": 1075,
+          "scm": 207,
+          "roll": 120,
+          "pitch": 38,
+          "yaw": 35
+        },
+        "emission": {
+          "ir": 9826,
+          "em_idle": 7683,
+          "em_max": 27197
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 37.2
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticcannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticcannon_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticcannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticcannon_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 8,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Anvil Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Anvil Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 9200,
+        "wing right (front)": 500,
+        "wing left (front)": 500,
+        "nose": 7650,
+        "canopy": 350,
+        "tail left": 250,
+        "tail right": 250,
+        "hardpoint thruster rr (top)": 10,
+        "wing base (right)": 6000,
+        "wing flap right (top)": 250,
+        "fin bot (right)": 500,
+        "fin (top right)": 500,
+        "wing (right)": 500,
+        "weapon mount wing a s4 (right)": 200,
+        "weapon mount wing b s3 (right)": 200,
+        "mini wing (right)": 250,
+        "wing right (rear)": 2000,
+        "wing flap right (rear)": 250,
+        "engine center": 200,
+        "hardpoint engine mid": 10,
+        "wing base (left)": 6000,
+        "wing flap left (top)": 250,
+        "fin (top left)": 500,
+        "fin bot (left)": 500,
+        "wing (left)": 500,
+        "weapon mount wing a s4 (left)": 200,
+        "weapon mount wing b s3 (left)": 200,
+        "mini wing (left)": 250,
+        "wing left (rear)": 2000,
+        "wing flap left (rear)": 250
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s02_sheut_scitem"
+          },
+          {
+            "class": "shld_asas_s02_sheut_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s01_expedition_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "MISC_Fortune": {
+      "name": "Fortune",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 16,
+        "stowage": 650000,
+        "speed": {
+          "max": 975,
+          "scm": 143,
+          "roll": 75,
+          "pitch": 32,
+          "yaw": 32
+        },
+        "emission": {
+          "ir": 12411,
+          "em_idle": 11351,
+          "em_max": 32147
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 21
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "nose": 15200,
+        "tail": 8000,
+        "geo spoiler": 500,
+        "geo fortune thruster (rear right)": 6000,
+        "geo fortune thruster (rear left)": 6000,
+        "geo spine": 200,
+        "body": 15200,
+        "geo cargo grid panels (left)": 200,
+        "geo cargo grid panels (right)": 200,
+        "geo fortune thruster (front left)": 4000,
+        "geo fortune thruster (front right)": 4000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          },
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          },
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s02_trommel_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s02_snowfall_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s01_goliath_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "MISC_Freelancer": {
+      "name": "Freelancer",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": 1697600,
+        "crew": 1,
+        "cargo": 66,
+        "stowage": 4910000,
+        "speed": {
+          "max": 1050,
+          "scm": 197,
+          "roll": 103,
+          "pitch": 32,
+          "yaw": 30
+        },
+        "emission": {
+          "ir": 10019,
+          "em_idle": 13290,
+          "em_max": 42911
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 108
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "misc_freelancer_base_scitem_turret"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 4,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        },
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "nose": 9500,
+        "body": 9500,
+        "tail": 6200,
+        "wing (right)": 1960,
+        "wingflap (right)": 640,
+        "wing (left)": 1960,
+        "wingflap (left)": 640,
+        "roof scoop": 1200
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_behr_s02_5ma_scitem"
+          },
+          {
+            "class": "shld_behr_s02_5ma_scitem"
+          },
+          {
+            "class": "shld_behr_s02_5ma_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_sasu_s02_daybreak_scitem"
+          },
+          {
+            "class": "powr_sasu_s02_daybreak_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s02_froststarex_scitem"
+          },
+          {
+            "class": "cool_jspn_s02_froststarex_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s02_odyssey_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Traveler Rentals, Port Tressler",
+        "Traveler Rentals, Everus Harbor",
+        "Traveler Rentals, Baijini Point"
+      ]
+    },
+    "MISC_Freelancer_DUR": {
+      "name": "Freelancer DUR",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": 1967600,
+        "crew": 1,
+        "cargo": 36,
+        "stowage": 5080000,
+        "speed": {
+          "max": 1100,
+          "scm": 200,
+          "roll": 103,
+          "pitch": 34,
+          "yaw": 30
+        },
+        "emission": {
+          "ir": 11206,
+          "em_idle": 13762,
+          "em_max": 43583
+        },
+        "fuel": {
+          "quantum": 2.4,
+          "hydro": 140
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "misc_freelancer_base_scitem_turret"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "hrst_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "hrst_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "hrst_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "hrst_laserrepeater_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_em_taln_dominator"
+        },
+        {
+          "size": 3,
+          "count": 4,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "nose": 5500,
+        "body": 6200,
+        "tail": 3200,
+        "wing (left)": 1960,
+        "fuel tank (left upper)": 300,
+        "wingflap (left)": 640,
+        "fuel tank (left lower)": 300,
+        "wing (right)": 1960,
+        "fuel tank (right upper)": 300,
+        "wingflap (right)": 640,
+        "fuel tank (right lower)": 300,
+        "roof scoop": 1200
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_behr_s02_5ma_scitem"
+          },
+          {
+            "class": "shld_behr_s02_5ma_scitem"
+          },
+          {
+            "class": "shld_behr_s02_5ma_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_sasu_s02_daybreak_scitem"
+          },
+          {
+            "class": "powr_sasu_s02_daybreak_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s02_froststarex_scitem"
+          },
+          {
+            "class": "cool_jspn_s02_froststarex_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s02_odyssey_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "MISC_Freelancer_MAX": {
+      "name": "Freelancer MAX",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": 2181500,
+        "crew": 1,
+        "cargo": 120,
+        "stowage": 4910000,
+        "speed": {
+          "max": 1025,
+          "scm": 195,
+          "roll": 95,
+          "pitch": 30,
+          "yaw": 28
+        },
+        "emission": {
+          "ir": 12964,
+          "em_idle": 16290,
+          "em_max": 46511
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 58.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "misc_freelancer_base_scitem_turret"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 4,
+          "missle-class": "misl_s03_em_fski_thunderbolt"
+        },
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_em_taln_dominator"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "nose": 5500,
+        "body": 6200,
+        "tail": 3200,
+        "roof scoop": 1200,
+        "wing (left)": 1960,
+        "wingflap (left)": 640,
+        "wing (right)": 1960,
+        "wingflap (right)": 640
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_behr_s02_5ma_scitem"
+          },
+          {
+            "class": "shld_behr_s02_5ma_scitem"
+          },
+          {
+            "class": "shld_behr_s02_5ma_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_sasu_s02_daybreak_scitem"
+          },
+          {
+            "class": "powr_sasu_s02_daybreak_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s02_froststarex_scitem"
+          },
+          {
+            "class": "cool_jspn_s02_froststarex_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s02_odyssey_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "MISC_Freelancer_MIS": {
+      "name": "Freelancer MIS",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": 2537800,
+        "crew": 1,
+        "cargo": 36,
+        "stowage": 3710000,
+        "speed": {
+          "max": 1000,
+          "scm": 204,
+          "roll": 107,
+          "pitch": 35,
+          "yaw": 31
+        },
+        "emission": {
+          "ir": 10269,
+          "em_idle": 13450,
+          "em_max": 46852
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 58
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "misc_freelancer_base_scitem_turret"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 20,
+          "missle-class": "misl_s03_em_fski_thunderbolt"
+        },
+        {
+          "size": 3,
+          "count": 8,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "nose": 5500,
+        "body": 6200,
+        "tail": 3200,
+        "wing (left)": 1960,
+        "wingflap (left)": 640,
+        "wing (right)": 1960,
+        "wingflap (right)": 640,
+        "roof scoop": 1200
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          },
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          },
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s02_crossfield_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "MISC_Fury": {
+      "name": "Fury",
+      "stats": {
+        "ship-size": "snub",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 220000,
+        "speed": {
+          "max": 1263,
+          "scm": 238,
+          "roll": 215,
+          "pitch": 65,
+          "yaw": 65
+        },
+        "emission": {
+          "ir": 8416,
+          "em_idle": 2672,
+          "em_max": 9922
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 2.75
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 1486,
+        "mesh wing (bottom right)": 340,
+        "mesh flap (bottom right)": 340,
+        "mesh slide (bottom right)": 340,
+        "mesh wing (bottom left)": 340,
+        "mesh flap (bottom left)": 340,
+        "mesh slide (bottom left)": 340,
+        "mesh wing (top right)": 340,
+        "mesh flap (top right)": 340,
+        "mesh slide (top right)": 340,
+        "mesh wing (top left)": 340,
+        "mesh flap (top left)": 340,
+        "mesh slide (top left)": 340,
+        "plate (front lower)": 500,
+        "body plate (top)": 500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_cloak_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s01_roughneck_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s01_hydrocel_scitem"
+          },
+          {
+            "class": "cool_just_s01_hydrocel_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "MISC_Fury_LX": {
+      "name": "Fury LX",
+      "stats": {
+        "ship-size": "snub",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 220000,
+        "speed": {
+          "max": 1281,
+          "scm": 249,
+          "roll": 232.1,
+          "pitch": 71.5,
+          "yaw": 71.5
+        },
+        "emission": {
+          "ir": 7916,
+          "em_idle": 1332,
+          "em_max": 8582
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 2.75
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "body": 1377,
+        "mesh wing (top right)": 240,
+        "mesh wing (top left)": 240,
+        "mesh wing (bottom right)": 240,
+        "mesh wing (bottom left)": 240,
+        "plate (front lower)": 400,
+        "body plate (top)": 400
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_yorm_s01_falco_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s01_roughneck_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_acom_s01_iceplunge_scitem"
+          },
+          {
+            "class": "cool_acom_s01_iceplunge_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "MISC_Fury_Miru": {
+      "name": "Fury MX",
+      "stats": {
+        "ship-size": "snub",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 220000,
+        "speed": {
+          "max": 1263,
+          "scm": 238,
+          "roll": 215,
+          "pitch": 65,
+          "yaw": 65
+        },
+        "emission": {
+          "ir": 7016,
+          "em_idle": 1932,
+          "em_max": 9182
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 2.75
+        }
+      },
+      "weapons": [],
+      "missles": [
+        {
+          "size": 2,
+          "count": 12,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        },
+        {
+          "size": 1,
+          "count": 8,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 1486,
+        "mesh wing (bottom right)": 340,
+        "mesh flap (bottom right)": 340,
+        "mesh slide (bottom right)": 340,
+        "mesh wing (bottom left)": 340,
+        "mesh flap (bottom left)": 340,
+        "mesh slide (bottom left)": 340,
+        "mesh wing (top right)": 340,
+        "mesh flap (top right)": 340,
+        "mesh slide (top right)": 340,
+        "mesh wing (top left)": 340,
+        "mesh flap (top left)": 340,
+        "mesh slide (top left)": 340,
+        "plate (front lower)": 500,
+        "body plate (top)": 500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_cloak_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s01_roughneck_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s01_hydrocel_scitem"
+          },
+          {
+            "class": "cool_just_s01_hydrocel_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ANVL_Gladiator": {
+      "name": "Gladiator",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1954500,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 2580000,
+        "speed": {
+          "max": 1125,
+          "scm": 210,
+          "roll": 130,
+          "pitch": 40,
+          "yaw": 40
+        },
+        "emission": {
+          "ir": 8445,
+          "em_idle": 8603,
+          "em_max": 27565
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 15
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s4"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "anvl_gladiator_scitem_turret"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 8,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        },
+        {
+          "size": 3,
+          "count": 4,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        },
+        {
+          "size": 5,
+          "count": 4,
+          "missle-class": "misl_s05_cs_taln_stalker"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "fin left rudder (tail)": 400,
+        "geo fin right rudder (tail)": 200,
+        "geo fin left rudder (tail)": 200,
+        "body": 5500,
+        "wing (left)": 800,
+        "wing tip (left)": 400,
+        "wing flap main (left)": 200,
+        "wing flap side (left)": 200,
+        "core shield (bottom)": 800,
+        "core shield (top)": 800,
+        "bombbay outerdoor (right)": 600,
+        "bombbay outerdoor (left)": 600,
+        "hull fuelaccess panel (right)": 400,
+        "hull fuelaccess panel (left)": 400,
+        "hull avionicsaccess panel": 400,
+        "cockpitbay gunnerdoor": 400,
+        "wing (right)": 800,
+        "wing tip (right)": 400,
+        "wing flap main (right)": 200,
+        "wing flap side (right)": 200,
+        "tail": 2250,
+        "fin right (tail)": 800,
+        "sidefin (right)": 400,
+        "fin left (tail)": 800,
+        "sidefin (left)": 400,
+        "engine cover (right)": 400,
+        "engine cover (left)": 400,
+        "amunition hatch (left)": 400,
+        "amunition hatch (right)": 400,
+        "nose": 5500,
+        "canopy": 7500,
+        "canopy glass": 250,
+        "cockpitbay outerdoor (right)": 500,
+        "cockpitbay outerdoor (left)": 500,
+        "shield generator cover": 400
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s01_beacon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "AEGS_Gladius": {
+      "name": "Gladius",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1169900,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1300000,
+        "speed": {
+          "max": 1193,
+          "scm": 226,
+          "roll": 200,
+          "pitch": 68,
+          "yaw": 52
+        },
+        "emission": {
+          "ir": 8491,
+          "em_idle": 4941,
+          "em_max": 20306
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 13.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 2,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        },
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 2350,
+        "nose": 600,
+        "canopy": 100,
+        "wing left (front)": 50,
+        "wing right (front)": 50,
+        "rudder (left)": 50,
+        "rudder flap (left)": 50,
+        "wingleft (rear)": 50,
+        "wingleft flap (rear)": 50,
+        "wingright (rear)": 50,
+        "wingright flap (rear)": 50,
+        "rudder (right)": 50,
+        "rudder flap (right)": 50,
+        "belly": 240,
+        "belly wing (right)": 150,
+        "belly wing (left)": 150,
+        "wing (right)": 600,
+        "wingtip (right)": 260,
+        "wingflap (right mid)": 50,
+        "tipwing b (right)": 50,
+        "tipwing a (right)": 50,
+        "wing (left)": 600,
+        "wingtip (left)": 260,
+        "wingflap (left mid)": 50,
+        "tipwing a (left)": 50,
+        "tipwing b (left)": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          },
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s01_beacon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "AEGS_Gladius_Valiant": {
+      "name": "Gladius Valiant",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1429800,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1300000,
+        "speed": {
+          "max": 1193,
+          "scm": 226,
+          "roll": 200,
+          "pitch": 68,
+          "yaw": 52
+        },
+        "emission": {
+          "ir": 8551,
+          "em_idle": 5417,
+          "em_max": 20747
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 13.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 2,
+          "missle-class": "misl_s03_ir_novp_viper"
+        },
+        {
+          "size": 1,
+          "count": 8,
+          "missle-class": "misl_s01_em_behr_pioneer"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 2350,
+        "nose": 600,
+        "canopy": 100,
+        "wing left (front)": 50,
+        "wing right (front)": 50,
+        "rudder (left)": 50,
+        "rudder flap (left)": 50,
+        "wingleft (rear)": 50,
+        "wingleft flap (rear)": 50,
+        "wingright (rear)": 50,
+        "wingright flap (rear)": 50,
+        "rudder (right)": 50,
+        "rudder flap (right)": 50,
+        "belly": 240,
+        "belly wing (right)": 150,
+        "belly wing (left)": 150,
+        "wing (right)": 600,
+        "wingtip (right)": 260,
+        "wingflap (right mid)": 50,
+        "tipwing b (right)": 50,
+        "tipwing a (right)": 50,
+        "wing (left)": 600,
+        "wingtip (left)": 260,
+        "wingflap (left mid)": 50,
+        "tipwing a (left)": 50,
+        "tipwing b (left)": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          },
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s01_beacon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "VNCL_Glaive": {
+      "name": "Glaive",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1590000,
+        "speed": {
+          "max": 1150,
+          "scm": 218,
+          "roll": 155,
+          "pitch": 60,
+          "yaw": 43
+        },
+        "emission": {
+          "ir": 9180,
+          "em_idle": 7343,
+          "em_max": 22463
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 9
+        }
+      },
+      "weapons": [],
+      "missles": [
+        {
+          "size": 2,
+          "count": 8,
+          "missle-class": "misl_s02_ir_vncl_bullet"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "nose": 5000,
+        "body": 5000,
+        "wing arm (left)": 720,
+        "wing d (left tail)": 1,
+        "wing d featherb hinge (left tail)": 1,
+        "wing d featherb end (left tail)": 1,
+        "wing d featherd hinge (left tail)": 1,
+        "wing d featherd end (left tail)": 1,
+        "wing d featherc hinge (left tail)": 1,
+        "wing d featherc end (left tail)": 1,
+        "wing d feathera hinge (left tail)": 1,
+        "wing d feathera end (left tail)": 1,
+        "wing gun (left)": 640,
+        "wing a (left)": 720,
+        "wing blade lock (left)": 1,
+        "wing a featherd hinge (left)": 1,
+        "wing a featherd end (left)": 1,
+        "wing a featherc hinge (left)": 1,
+        "wing a featherc end (left)": 1,
+        "wing a featherb hinge (left)": 1,
+        "wing a featherb end (left)": 1,
+        "wing a feathera hinge (left)": 1,
+        "wing a feathera end (left)": 1,
+        "wing blade (left)": 1000,
+        "wing c (left tail)": 1,
+        "wing b (left tail)": 1,
+        "wing a (left tail)": 1,
+        "wing arm (right)": 640,
+        "wing d (right tail)": 1,
+        "wing d featherd hinge (right tail)": 1,
+        "wing d featherd end (right tail)": 1,
+        "wing d featherc hinge (right tail)": 1,
+        "wing d featherc end (right tail)": 1,
+        "wing d featherb hinge (right tail)": 1,
+        "wing d featherb end (right tail)": 1,
+        "wing d feathera hinge (right tail)": 1,
+        "wing d feathera end (right tail)": 1,
+        "wing c (right tail)": 1,
+        "wing b (right tail)": 1,
+        "wing a (right tail)": 1,
+        "wing gun (right)": 640,
+        "wing a (right)": 720,
+        "wing blade lock (right)": 1,
+        "wing a feathera hinge (right)": 1,
+        "wing a feathera end (right)": 1,
+        "wing a featherb hinge (right)": 1,
+        "wing a featherb end (right)": 1,
+        "wing a featherc hinge (right)": 1,
+        "wing a featherc end (right)": 1,
+        "wing a featherd hinge (right)": 1,
+        "wing a featherd end (right)": 1,
+        "wing blade (right)": 1000,
+        "landing gear cover (rear)": 200
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          },
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_fierellcascade_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s01_beacon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "DRAK_Golem": {
+      "name": "Golem",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 32,
+        "stowage": 1150000,
+        "speed": {
+          "max": 1010,
+          "scm": 203,
+          "roll": 140,
+          "pitch": 43,
+          "yaw": 43
+        },
+        "emission": {
+          "ir": 8211,
+          "em_idle": 1433,
+          "em_max": 16253
+        },
+        "fuel": {
+          "quantum": 0.95,
+          "hydro": 24
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 2,
+          "missle-class": "misl_s01_cs_fski_spark"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "m det fl vtol": 1450,
+        "m det fr vtol": 1450,
+        "m vtol cover right (rear)": 1000,
+        "m det vtol ext main housing (right)": 500,
+        "m vtol cover left (rear)": 1000,
+        "m det vtol ext main housing (left)": 500,
+        "body": 2350,
+        "m det fl cover (lower)": 500,
+        "m det fr cover (lower)": 500,
+        "m det fl cover": 1600,
+        "m det fr cover": 1600,
+        "m body (rear)": 2350,
+        "m det rl fin": 250,
+        "m det lside cover": 400,
+        "m det rside cover": 400,
+        "m det rl cover": 600,
+        "m det rr fin": 250,
+        "m det rr cover": 600
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s01_fortitude_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s01_thermax_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s01_goliath_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "MRAI_Guardian": {
+      "name": "Guardian",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 650000,
+        "speed": {
+          "max": 1125,
+          "scm": 213,
+          "roll": 130,
+          "pitch": 45,
+          "yaw": 45
+        },
+        "emission": {
+          "ir": 10076,
+          "em_idle": 5088,
+          "em_max": 29914
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 9
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 16,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "geo thruster arm b (right)": 5000,
+        "geo thruster arm c (right)": 5000,
+        "geo thruster arm b (left)": 5000,
+        "geo thruster arm c (left)": 5000,
+        "geo wing middle (bottom right)": 4000,
+        "geo wing (bottom right front)": 3000,
+        "geo landing gear housing (right front)": 100,
+        "geo wing (bottom right back)": 2500,
+        "geo wing middle (bottom left)": 4000,
+        "geo wing (bottom left front)": 3000,
+        "geo landing gear housing (left front)": 100,
+        "geo wing (bottom left back)": 2500,
+        "geo wing middle (right top)": 4000,
+        "geo wing (right top front)": 3000,
+        "geo wing (right top back)": 2500,
+        "geo wing middle (left top)": 4000,
+        "geo wing (left top front)": 3000,
+        "geo wing (left top back)": 2500,
+        "geo wing arm a (right rear top)": 300,
+        "geo wing arm a (left rear top)": 300,
+        "geo body": 7100,
+        "geo body b (top front)": 300,
+        "geo body a (top front)": 3000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_amrs_s01_overdrive_scitem"
+          },
+          {
+            "class": "powr_amrs_s01_overdrive_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s02_crossfield_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "MRAI_Guardian_MX": {
+      "name": "Guardian MX",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 0,
+        "speed": {
+          "max": 1100,
+          "scm": 208,
+          "roll": 120,
+          "pitch": 39,
+          "yaw": 39
+        },
+        "emission": {
+          "ir": 11131,
+          "em_idle": 7214,
+          "em_max": 33915
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 9
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s4"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 24,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "geo body": 8100,
+        "geo thruster arm b (right)": 6000,
+        "geo thruster arm c (right)": 6000,
+        "geo thruster arm b (left)": 6000,
+        "geo thruster arm c (left)": 6000,
+        "geo wing arm (rear bottom right)": 5000,
+        "geo guardian mx wing (bottom right)": 5000,
+        "geo flap 01 wing (bottom right)": 1200,
+        "geo flap 02 wing (bottom right)": 700,
+        "geo wing hinge attach (right)": 1000,
+        "geo lg panel b (front right)": 50,
+        "geo wing arm a right (rear top)": 5000,
+        "geo guardian mx wing (top right)": 5000,
+        "geo flap 02 wing (top right)": 700,
+        "geo wing arm a left (rear top)": 5000,
+        "geo guardian mx wing (top left)": 5000,
+        "geo flap 02 wing (top left)": 700,
+        "geo wing arm (rear bottom left)": 5000,
+        "geo guardian mx wing (bottom left)": 5000,
+        "geo flap 02 wing (bottom left)": 700,
+        "geo flap 01 wing (bottom left)": 1200,
+        "geo wing hinge attach (left)": 1000,
+        "geo lg panel b (front left)": 50,
+        "geo body (top)": 1900,
+        "geo body shell (back)": 1200,
+        "nose": 5600,
+        "geo nose cap": 1200
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s02_crossfield_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "MRAI_Guardian_QI": {
+      "name": "Guardian QI",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 650000,
+        "speed": {
+          "max": 1100,
+          "scm": 210,
+          "roll": 125,
+          "pitch": 42,
+          "yaw": 42
+        },
+        "emission": {
+          "ir": 10191,
+          "em_idle": 7588,
+          "em_max": 36352
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 9
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 8,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "geo thruster arm b (right)": 5000,
+        "geo thruster arm c (right)": 5000,
+        "geo thruster arm b (left)": 5000,
+        "geo thruster arm c (left)": 5000,
+        "geo wing middle (bottom right)": 4000,
+        "geo wing (bottom right front)": 3000,
+        "geo landing gear housing (right front)": 100,
+        "geo wing (bottom right back)": 2500,
+        "geo wing middle (bottom left)": 4000,
+        "geo wing (bottom left front)": 3000,
+        "geo landing gear housing (left front)": 100,
+        "geo wing (bottom left back)": 2500,
+        "geo wing middle (right top)": 4000,
+        "geo wing (right top front)": 3000,
+        "geo wing (right top back)": 2500,
+        "geo wing middle (left top)": 4000,
+        "geo wing (left top front)": 3000,
+        "geo wing (left top back)": 2500,
+        "geo wing arm a (right rear top)": 300,
+        "geo wing arm a (left rear top)": 300,
+        "geo body": 7000,
+        "geo body b (top front)": 300,
+        "geo body a (top front)": 3000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          },
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s02_crossfield_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "AEGS_Hammerhead": {
+      "name": "Hammerhead",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": 12459900,
+        "crew": 2,
+        "cargo": 0,
+        "stowage": 10280000,
+        "speed": {
+          "max": 950,
+          "scm": 160,
+          "roll": 30,
+          "pitch": 20,
+          "yaw": 18
+        },
+        "emission": {
+          "ir": 22480,
+          "em_idle": 20559,
+          "em_max": 53491
+        },
+        "fuel": {
+          "quantum": 6.6,
+          "hydro": 450
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_hammerhead_scitem_turret_rear"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_hammerhead_scitem_turret_side_backleft"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_hammerhead_scitem_turret_side_backright"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_hammerhead_scitem_turret_side_frontleft"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_hammerhead_scitem_turret_side_frontright"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_hammerhead_scitem_turret_top"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 16,
+          "missle-class": "misl_s03_ir_novp_viper"
+        },
+        {
+          "size": 3,
+          "count": 16,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 80000,
+        "engine mounta (left)": 10000,
+        "engine mounta (right)": 10000,
+        "engine mountb (left)": 10000,
+        "engine mountb (right)": 10000,
+        "front left": 15200,
+        "front right": 15200,
+        "nose": 80000,
+        "tail": 65000,
+        "custom decal": 200
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          },
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_amrs_s03_superdrive_scitem"
+          },
+          {
+            "class": "powr_amrs_s03_superdrive_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s03_mercury_scitem"
+          },
+          {
+            "class": "cool_aegs_s03_mercury_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s03_kama_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "ANVL_Hawk": {
+      "name": "Hawk",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1284400,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1300000,
+        "speed": {
+          "max": 1217,
+          "scm": 225,
+          "roll": 190,
+          "pitch": 63,
+          "yaw": 52
+        },
+        "emission": {
+          "ir": 8365,
+          "em_idle": 8313,
+          "em_max": 25035
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 10.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "jokr_distortioncannon_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "jokr_distortioncannon_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "body": 2000,
+        "tail": 1500,
+        "nose": 2000,
+        "nacelle (right)": 1900,
+        "wing (right)": 1000,
+        "wing right (rear)": 1900,
+        "nacelle (left)": 1900,
+        "wing (left)": 1000,
+        "wing left (rear)": 1900,
+        "canopy": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          },
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_arcc_s01_rush_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "DRAK_Herald": {
+      "name": "Herald",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1181100,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 840000,
+        "speed": {
+          "max": 1450,
+          "scm": 245,
+          "roll": 150,
+          "pitch": 47,
+          "yaw": 40
+        },
+        "emission": {
+          "ir": 7741,
+          "em_idle": 6211,
+          "em_max": 20445
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 10.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 18,
+          "missle-class": "misl_s02_em_taln_dominator"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "tail": 1400,
+        "pipe cover (left)": 100,
+        "pipe cover (right)": 100,
+        "body": 2880,
+        "wingdetach (right)": 660,
+        "wingdetach (left)": 660,
+        "sat array (lower left)": 100,
+        "sat flap (left)": 100,
+        "sat flap (right)": 100,
+        "sat array (upper left)": 100,
+        "sat flap (lower)": 100,
+        "sat array (upper right)": 100,
+        "sat array (lower right)": 100
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          },
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_tydt_s01_slipstream_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_tydt_s01_heatsafe_scitem"
+          },
+          {
+            "class": "cool_tydt_s01_heatsafe_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s01_expedition_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "CNOU_HoverQuad": {
+      "name": "HoverQuad",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": 88000,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1200000,
+        "speed": {
+          "max": 550,
+          "scm": 200,
+          "roll": 130,
+          "pitch": 70,
+          "yaw": 70
+        },
+        "emission": {
+          "ir": 1965,
+          "em_idle": 1406,
+          "em_max": 13188
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 1.6
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "body": 750,
+        "nose": 750,
+        "gravlev nacelle f (left)": 450,
+        "gravlev nacelle f (right)": 450,
+        "gravlev nacelle r (right)": 450,
+        "gravlev nacelle r (left)": 450,
+        "hardpoint vehicle destroyed": 200
+      },
+      "components": {
+        "shields": [],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_wcpr_s00_fridan_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Astro Armada, Area 18"
+      ]
+    },
+    "MISC_Hull_A": {
+      "name": "Hull A",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1375500,
+        "crew": 1,
+        "cargo": 64,
+        "stowage": 1010000,
+        "speed": {
+          "max": 950,
+          "scm": 140,
+          "roll": 100,
+          "pitch": 35,
+          "yaw": 35
+        },
+        "emission": {
+          "ir": 11176,
+          "em_idle": 10499,
+          "em_max": 26463
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 16.4
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "body": 20000,
+        "nose": 20000,
+        "door geo (front left)": 400,
+        "door geo (front right)": 400,
+        "door 01 geo centre (right)": 400,
+        "door 02 geo centre (right)": 400,
+        "door 01 geo centre (left)": 400,
+        "door lock geo centre (left)": 400,
+        "door 02 geo centre (left)": 400,
+        "piston 01 geo": 400,
+        "piston 02 tube": 400,
+        "piston 02 geo": 400,
+        "hydraulic arm geo right (back)": 400,
+        "hydraulic arm geo left (back)": 400,
+        "geo (tail)": 3000,
+        "geo top (tail)": 1500,
+        "geo bot (tail)": 1500,
+        "geo spinner (tail)": 400,
+        "door 01 geo (rear right)": 100,
+        "door lock geo (rear right)": 100,
+        "door 02 geo (rear right)": 100,
+        "hydraulic arm geo right (front)": 1000,
+        "hydraulic arm connector geo (right)": 1000,
+        "hydraulic cargoplates mount geo (right)": 1000,
+        "debris cargoplate bot (right)": 2000,
+        "shield sdf 04 rb": 4000,
+        "shield sdf 03 rb": 4000,
+        "shield sdf 02 rb": 4000,
+        "shield sdf 01 rb": 4000,
+        "debris cargoplate (top right)": 2000,
+        "shield sdf 04 rt": 4000,
+        "shield sdf 03 rt": 4000,
+        "shield sdf 02 rt": 4000,
+        "shield sdf 01 rt": 4000,
+        "hydraulic arm geo left (front)": 1000,
+        "hydraulic arm connector geo (left)": 1000,
+        "hydraulic cargoplates mount geo (left)": 1000,
+        "debris cargoplate bot (left)": 2000,
+        "shield sdf 04 lb": 4000,
+        "shield sdf 03 lb": 4000,
+        "shield sdf 02 lb": 4000,
+        "shield sdf 01 lb": 4000,
+        "debris cargoplate (top left)": 2000,
+        "shield sdf 04 lt": 4000,
+        "shield sdf 03 lt": 4000,
+        "shield sdf 02 lt": 4000,
+        "shield sdf 01 lt": 4000,
+        "spindle connector geo (rear)": 400,
+        "winglet (left)": 150,
+        "winglet (right)": 150
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s02_armada_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s01_ionburst_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_lplt_s01_arcticstorm_scitem"
+          },
+          {
+            "class": "cool_lplt_s01_arcticstorm_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s01_goliath_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "MISC_Hull_C": {
+      "name": "Hull C",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 4608,
+        "stowage": 6790000,
+        "speed": {
+          "max": 890,
+          "scm": 110,
+          "roll": 25,
+          "pitch": 16,
+          "yaw": 16
+        },
+        "emission": {
+          "ir": 26532,
+          "em_idle": 32513,
+          "em_max": 70330
+        },
+        "fuel": {
+          "quantum": 8.6,
+          "hydro": 877
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "body": 60000,
+        "tunnel (front)": 10000,
+        "center 1 ph geo": 8000,
+        "rear": 20500,
+        "center": 9000,
+        "engine (right)": 8000,
+        "enginedebris001": 1000,
+        "engine (top right)": 8000,
+        "engine (left)": 8000,
+        "enginedebris": 1000,
+        "engine (top left)": 8000,
+        "debris strut inner002": 8000,
+        "debris strut outer002": 8000,
+        "debris strut inner003": 8000,
+        "debris strut outer003": 8000,
+        "debris strut inner004": 8000,
+        "debris strut outer004": 8000,
+        "debris strut inner001": 8000,
+        "debris strut outer001": 8000,
+        "debris strut inner008": 8000,
+        "debris strut outer008": 8000,
+        "debris strut inner007": 8000,
+        "debris strut outer007": 8000,
+        "debris strut inner006": 8000,
+        "debris strut outer006": 8000,
+        "debris strut inner005": 8000,
+        "debris strut outer005": 8000,
+        "foldingsection001 geo": 8000,
+        "nose": 30000,
+        "vtol door r geo": 8000,
+        "vtol door l geo": 8000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          },
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          },
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s03_centurion_scitem"
+          }
+        ],
+        "coolers": [],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ANVL_Hurricane": {
+      "name": "Hurricane",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1218300,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 3870000,
+        "speed": {
+          "max": 1125,
+          "scm": 214,
+          "roll": 130,
+          "pitch": 46,
+          "yaw": 37
+        },
+        "emission": {
+          "ir": 9436,
+          "em_idle": 9173,
+          "em_max": 28091
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 13.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s4"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "anvl_hurricane_scitem_turret"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 7000,
+        "stabilizer (right)": 50,
+        "stabilizer flap (right)": 25,
+        "wing (top right)": 600,
+        "wing flap (top right)": 25,
+        "wing (bottom right)": 800,
+        "wing flap (bottom right)": 25,
+        "hardpoint missile wing 02 s2 (right)": 10,
+        "hardpoint missile wing 01 s2 (right)": 10,
+        "hardpoint missile wing 02 s2 (left)": 10,
+        "hardpoint missile wing 01 s2 (left)": 10,
+        "wing (top left)": 800,
+        "wing flap (top left)": 25,
+        "stabilizer (left)": 50,
+        "stabilizer flap (left)": 25,
+        "wing (bottom left)": 500,
+        "wing flap (bottom left)": 1,
+        "hardpoint thruster main (left)": 10,
+        "hardpoint thruster main (right)": 10,
+        "hardpoint thruster mav bot left (rear)": 10,
+        "hardpoint thruster mav bot right (rear)": 10,
+        "hardpoint thruster mav (rear top right)": 10,
+        "hardpoint thruster mav (rear top left)": 10,
+        "nose": 7800,
+        "canopy interior": 250,
+        "canopy exterior": 250,
+        "hardpoint thruster mav bot left (front)": 10,
+        "hardpoint thruster mav bot right (front)": 10,
+        "hardpoint thruster mav (front top left)": 10,
+        "hardpoint thruster mav (front top right)": 10,
+        "hardpoint thruster retro (right)": 10,
+        "hardpoint thruster retro (left)": 10
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          },
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s01_expedition_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "AEGS_Idris_M": {
+      "name": "Idris-M",
+      "stats": {
+        "ship-size": "capital",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 1326,
+        "stowage": 32000000,
+        "speed": {
+          "max": 850,
+          "scm": 110,
+          "roll": 12,
+          "pitch": 7,
+          "yaw": 7
+        },
+        "emission": {
+          "ir": 37860,
+          "em_idle": 41411,
+          "em_max": 139581
+        },
+        "fuel": {
+          "quantum": 120,
+          "hydro": 25600
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_idris_scitem_turret_large"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_idris_scitem_turret_lower_short_left"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_idris_scitem_turret_upper_front_left"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "door_ship_exterior_idris_turret_cover"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_idris_scitem_turret_upper_rear_left"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_idris_scitem_turret_upper_rear_right"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_idris_scitem_turret_lower_short_right"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_idris_scitem_turret_upper_front_right"
+        }
+      ],
+      "missles": [
+        {
+          "size": 5,
+          "count": 10,
+          "missle-class": "misl_s05_cs_taln_stalker"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "idris thruster main 01 (right)": 300000,
+        "idris thruster main 01 (left)": 300000,
+        "body": 3600000,
+        "walkway (right)": 100000,
+        "engine mount right (tail)": 100000,
+        "idris thruster main 02 (right)": 200000,
+        "tail": 2150000,
+        "antennamount (tail)": 190000,
+        "radar": 190000,
+        "escapepod door (rear right)": 5000,
+        "escapepod door (rear left)": 5000,
+        "idris thruster main 01 (rearright)": 300000,
+        "idris thruster main 01 (rearleft)": 300000,
+        "bridge": 2150000,
+        "walkway (left)": 1000000,
+        "engine mount left (tail)": 300000,
+        "idris thruster main 02 (left)": 200000,
+        "nose": 2750000,
+        "nose vfx hack": 1000000,
+        "airlock section": 375000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s04_idris_scitem"
+          },
+          {
+            "class": "shld_godi_s04_idris_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s04_idris_scitem"
+          },
+          {
+            "class": "powr_aegs_s04_idris_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s04_idris_scitem"
+          },
+          {
+            "class": "cool_aegs_s04_idris_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s04_idris_temp"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "AEGS_Idris_P": {
+      "name": "Idris-P",
+      "stats": {
+        "ship-size": "capital",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 1374,
+        "stowage": 32000000,
+        "speed": {
+          "max": 850,
+          "scm": 110,
+          "roll": 12,
+          "pitch": 7,
+          "yaw": 7
+        },
+        "emission": {
+          "ir": 38685,
+          "em_idle": 41532,
+          "em_max": 139878
+        },
+        "fuel": {
+          "quantum": 120,
+          "hydro": 25600
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_idris_scitem_turret_large_p"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_idris_scitem_turret_lower_short_left"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_idris_scitem_turret_upper_front_left"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_idris_scitem_turret_lower"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_idris_scitem_turret_upper_rear_left"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_idris_scitem_turret_upper_rear_right"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_idris_scitem_turret_lower_short_right"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_idris_scitem_turret_upper_front_right"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "idris thruster main 01 (right)": 300000,
+        "idris thruster main 01 (left)": 300000,
+        "body": 3600000,
+        "walkway (right)": 100000,
+        "engine mount right (tail)": 100000,
+        "idris thruster main 02 (right)": 200000,
+        "tail": 2150000,
+        "antennamount (tail)": 190000,
+        "radar": 190000,
+        "escapepod door (rear right)": 5000,
+        "escapepod door (rear left)": 5000,
+        "idris thruster main 01 (rearright)": 300000,
+        "idris thruster main 01 (rearleft)": 300000,
+        "bridge": 2150000,
+        "walkway (left)": 1000000,
+        "engine mount left (tail)": 300000,
+        "idris thruster main 02 (left)": 200000,
+        "nose": 2750000,
+        "nose vfx hack": 1000000,
+        "airlock section": 375000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s04_idris_scitem"
+          },
+          {
+            "class": "shld_godi_s04_idris_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s04_idris_scitem"
+          },
+          {
+            "class": "powr_aegs_s04_idris_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s04_idris_scitem"
+          },
+          {
+            "class": "cool_aegs_s04_idris_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s04_idris_temp"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "CRUS_Intrepid": {
+      "name": "Intrepid",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 8,
+        "stowage": 2000000,
+        "speed": {
+          "max": 1225,
+          "scm": 227,
+          "roll": 145,
+          "pitch": 48,
+          "yaw": 48
+        },
+        "emission": {
+          "ir": 9541,
+          "em_idle": 1727,
+          "em_max": 15147
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 26
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s4"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 2,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 3300,
+        "rear": 3300,
+        "wing (top right)": 450,
+        "vtol (right)": 200,
+        "wing (top left)": 450,
+        "vtol (left)": 200,
+        "wing (right)": 1000,
+        "wing (left)": 1000,
+        "fin right (rear)": 50,
+        "fin left (rear)": 50,
+        "plating engines (right)": 50,
+        "plating engines (left)": 50,
+        "engines (right)": 700,
+        "engines (left)": 700,
+        "nose": 3300,
+        "wing (front left)": 100,
+        "canopy": 150,
+        "wing (front right)": 100,
+        "plating weapon": 100,
+        "plating central right (top)": 50,
+        "plating central left (top)": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s01_hex_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_sasu_s01_lightblossom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_lplt_s01_blastchill_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_acas_s01_foxfire_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "AEGS_Javelin": {
+      "name": "Javelin",
+      "stats": {
+        "ship-size": "capital",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 32000000,
+        "speed": {
+          "max": 900,
+          "scm": 50,
+          "roll": 15,
+          "pitch": 7,
+          "yaw": 8
+        },
+        "emission": {
+          "ir": 39912,
+          "em_idle": 78441,
+          "em_max": 308662
+        },
+        "fuel": {
+          "quantum": 80,
+          "hydro": 20000
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_javelinballisticcannon_s7"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_javelinballisticcannon_s7"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s7"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s7"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_javelin_scitem_turret_lower_manned"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_javelinballisticcannon_s7"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_javelinballisticcannon_s7"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_javelinballisticcannon_s7"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_javelinballisticcannon_s7"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s7"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s7"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_javelin_scitem_turret_lower_manned"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_javelinballisticcannon_s7"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_javelinballisticcannon_s7"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s7"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s7"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_javelin_scitem_turret_manned"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s7"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s7"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_javelin_scitem_turret_manned_left"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s7"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s7"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_javelin_scitem_turret_manned_left"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s7"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s7"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_javelin_scitem_turret_manned"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_javelinballisticcannon_s7"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_javelinballisticcannon_s7"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s7"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s7"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_javelin_scitem_turret_lower_manned"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_javelinballisticcannon_s7"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_javelinballisticcannon_s7"
+        }
+      ],
+      "missles": [
+        {
+          "size": 4,
+          "count": 18,
+          "missle-class": "misl_s04_em_taln_raptor"
+        },
+        {
+          "size": 9,
+          "count": 2,
+          "missle-class": "misl_s09_cs_taln_argos"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 92,
+          "name": "Joker Defcon Flares Ammo"
+        },
+        {
+          "type": "decoy",
+          "count": 92,
+          "name": "Joker Defcon Flares Ammo"
+        },
+        {
+          "type": "decoy",
+          "count": 92,
+          "name": "Joker Defcon Flares Ammo"
+        },
+        {
+          "type": "decoy",
+          "count": 92,
+          "name": "Joker Defcon Flares Ammo"
+        },
+        {
+          "type": "decoy",
+          "count": 92,
+          "name": "Joker Defcon Flares Ammo"
+        },
+        {
+          "type": "decoy",
+          "count": 92,
+          "name": "Joker Defcon Flares Ammo"
+        },
+        {
+          "type": "decoy",
+          "count": 92,
+          "name": "Joker Defcon Flares Ammo"
+        },
+        {
+          "type": "decoy",
+          "count": 92,
+          "name": "Joker Defcon Flares Ammo"
+        }
+      ],
+      "health": {
+        "body": 5000000,
+        "wing (front right bottom)": 5000,
+        "wing (front right top)": 5000,
+        "bridge": 200000,
+        "body (left)": 6000,
+        "body (right)": 6000,
+        "neck": 1000000,
+        "nose": 200000,
+        "nose prong (left)": 200,
+        "wing (front left bottom)": 5000,
+        "wing (front left top)": 5000,
+        "nose prong (right)": 200,
+        "tail": 1000000,
+        "engine mount (right)": 200000,
+        "engine mount (left)": 200000,
+        "wing (rear left bottom)": 5000,
+        "wing (rear left top)": 5000,
+        "wing (rear right bottom)": 5000,
+        "wing (rear right top)": 5000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s04_javelin_scitem"
+          },
+          {
+            "class": "shld_godi_s04_javelin_scitem"
+          },
+          {
+            "class": "shld_godi_s04_javelin_scitem"
+          },
+          {
+            "class": "shld_godi_s04_javelin_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s04_idris_scitem"
+          },
+          {
+            "class": "powr_aegs_s04_idris_scitem"
+          },
+          {
+            "class": "powr_aegs_s04_idris_scitem"
+          },
+          {
+            "class": "powr_aegs_s04_idris_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s04_javelin_scitem"
+          },
+          {
+            "class": "cool_aegs_s04_javelin_scitem"
+          },
+          {
+            "class": "cool_aegs_s04_javelin_scitem"
+          },
+          {
+            "class": "cool_aegs_s04_javelin_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_aegs_s04_javelin_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "XIAN_Scout": {
+      "name": "Khartu-Al",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 2113900,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 2130000,
+        "speed": {
+          "max": 1183,
+          "scm": 224,
+          "roll": 210,
+          "pitch": 67,
+          "yaw": 67
+        },
+        "emission": {
+          "ir": 9946,
+          "em_idle": 6673,
+          "em_max": 22059
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 26
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s4"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "wing (left lower)": 300,
+        "wing (left upper)": 300,
+        "wing (right lower)": 300,
+        "wing (right upper)": 300,
+        "body": 2150,
+        "sub frame": 2000,
+        "wing thruster shoulder (left lower)": 300,
+        "wing thruster elbow (left lower)": 300,
+        "wing thruster housing (left lower)": 500,
+        "wing thruster shoulder (left upper)": 300,
+        "wing thruster elbow (left upper)": 300,
+        "wing thruster housing (left upper)": 500,
+        "wing thruster shoulder (right lower)": 300,
+        "wing thruster elbow (right lower)": 300,
+        "wing thruster housing (right lower)": 500,
+        "wing thruster shoulder (right upper)": 300,
+        "wing thruster elbow (right upper)": 300,
+        "wing thruster housing (right upper)": 500,
+        "small wing (right)": 300,
+        "small wing (left)": 300,
+        "cockpit rim": 1600,
+        "body nose": 2150
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_forcewall_scitem"
+          },
+          {
+            "class": "shld_godi_s01_forcewall_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_amrs_s01_dynaflux_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "KRIG_L21_Wolf": {
+      "name": "L-21 Wolf",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 0,
+        "speed": {
+          "max": 1225,
+          "scm": 230,
+          "roll": 210,
+          "pitch": 75,
+          "yaw": 52
+        },
+        "emission": {
+          "ir": 9796,
+          "em_idle": 2063,
+          "em_max": 15666
+        },
+        "fuel": {
+          "quantum": 0.9,
+          "hydro": 9
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "krig_ballisticgatling_bespoke_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "krig_ballisticgatling_bespoke_s4"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 8,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 1750,
+        "canopy": 200,
+        "fin (bottom)": 600,
+        "nacelle (right)": 1500,
+        "nacelle (left)": 1500,
+        "nose": 1750,
+        "fin large (back right)": 450,
+        "fin small (back right)": 150,
+        "fin large (back left)": 450,
+        "fin small (back left)": 150
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s01_hex_scitem"
+          },
+          {
+            "class": "shld_seco_s01_hex_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_sasu_s01_lightblossom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_lplt_s01_blastchill_scitem"
+          },
+          {
+            "class": "cool_lplt_s01_blastchill_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_acas_s01_foxfire_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "RSI_Lynx": {
+      "name": "Lynx",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": null,
+        "crew": 2,
+        "cargo": 0,
+        "stowage": 2460000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 1195,
+          "em_idle": 1416,
+          "em_max": 13640
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "rsi lynx": 1800,
+        "body": 11000,
+        "wheel6 mudguard": 150,
+        "wheel6": 1500,
+        "wheel5 mudguard": 150,
+        "wheel5": 1500,
+        "wheel4 mudguard": 150,
+        "wheel4": 1500,
+        "wheel3 mudguard": 150,
+        "wheel3": 1500,
+        "wheel2 mudguard": 150,
+        "wheel2": 1500,
+        "wheel1 mudguard": 150,
+        "wheel1": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "CRUS_Starlifter_M2": {
+      "name": "M2 Hercules",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": 5225300,
+        "crew": 3,
+        "cargo": 522,
+        "stowage": 3430000,
+        "speed": {
+          "max": 950,
+          "scm": 160,
+          "roll": 30,
+          "pitch": 20,
+          "yaw": 18
+        },
+        "emission": {
+          "ir": 21579,
+          "em_idle": 26860,
+          "em_max": 62116
+        },
+        "fuel": {
+          "quantum": 6.6,
+          "hydro": 132
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s5"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "body": 58500,
+        "door right (front)": 4500,
+        "door left (front)": 4500,
+        "nose mesh": 9100,
+        "wing (right)": 7930,
+        "wing (left)": 7930,
+        "tail right": 4680,
+        "tail left": 4680
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s03_fullblock_scitem"
+          },
+          {
+            "class": "shld_godi_s03_fullblock_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_amrs_s03_superdrive_scitem"
+          },
+          {
+            "class": "powr_amrs_s03_superdrive_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s03_mercury_scitem"
+          },
+          {
+            "class": "cool_aegs_s03_mercury_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s03_pontes_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Crusader Showroom, Orison"
+      ]
+    },
+    "ORIG_m50": {
+      "name": "M50",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1193800,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 430000,
+        "speed": {
+          "max": 1450,
+          "scm": 280,
+          "roll": 200,
+          "pitch": 55,
+          "yaw": 55
+        },
+        "emission": {
+          "ir": 6026,
+          "em_idle": 2483,
+          "em_max": 15733
+        },
+        "fuel": {
+          "quantum": 1,
+          "hydro": 3
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 2,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 800,
+        "enginecover": 200,
+        "nose": 800,
+        "wing (frontleft)": 50,
+        "wing (frontright)": 50,
+        "ladderhatch": 1,
+        "canopy": 80,
+        "powerplanthousing (left)": 200,
+        "wing (right)": 200,
+        "wing (left)": 200,
+        "tail": 840,
+        "powerplanthousing (right)": 200
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_yorm_s01_targa_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_acom_s01_lumacore_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_acom_s01_iceplunge_scitem"
+          },
+          {
+            "class": "cool_acom_s01_iceplunge_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_acas_s01_lightfire_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Astro Armada, Area 18",
+        "Vantage Rentals, Lorville",
+        "Regal Luxury Rentals, New Babbage"
+      ]
+    },
+    "RSI_Mantis": {
+      "name": "Mantis",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1230000,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 710000,
+        "speed": {
+          "max": 1393,
+          "scm": 236,
+          "roll": 160,
+          "pitch": 50,
+          "yaw": 42
+        },
+        "emission": {
+          "ir": 7125,
+          "em_idle": 9376,
+          "em_max": 28058
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 31.6125
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "kron_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "kron_lasercannon_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 6,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        },
+        {
+          "size": 2,
+          "count": 2,
+          "missle-class": "misl_s02_em_taln_dominator"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body main": 2626,
+        "wing (right)": 1800,
+        "wing right (tail)": 4000,
+        "engines base (right)": 2800,
+        "engine (right)": 2800,
+        "wing (left)": 1800,
+        "wing left (tail)": 4000,
+        "engines base (left)": 2800,
+        "engine (left)": 2800,
+        "frame interdiction (rear)": 200,
+        "interdiction cover right (bottom)": 50,
+        "interdiction cover left (bottom)": 50,
+        "interdiction cover left (top)": 50,
+        "interdiction cover right (top)": 50,
+        "cover mid (top)": 50,
+        "tail": 2500,
+        "nose wingmount (right)": 1050,
+        "hull (bottom)": 2000,
+        "nose wingmount (left)": 1050
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          },
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s01_beacon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "CRUS_Star_Runner": {
+      "name": "Mercury",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": 4912500,
+        "crew": 1,
+        "cargo": 114,
+        "stowage": 5930000,
+        "speed": {
+          "max": 1300,
+          "scm": 217,
+          "roll": 53,
+          "pitch": 25,
+          "yaw": 23
+        },
+        "emission": {
+          "ir": 14699,
+          "em_idle": 12840,
+          "em_max": 48396
+        },
+        "fuel": {
+          "quantum": 3.2,
+          "hydro": 100
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "crus_star_runner_turret_bottom"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "crus_star_runner_turret_top"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_cs_fski_tempest"
+        },
+        {
+          "size": 3,
+          "count": 2,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "wing (left)": 6600,
+        "wing (right)": 6600,
+        "nose": 14000,
+        "body": 14000,
+        "body engine": 200
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s02_diligence_scitem"
+          },
+          {
+            "class": "powr_just_s02_diligence_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s02_coolcore_scitem"
+          },
+          {
+            "class": "cool_just_s02_coolcore_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s02_bolon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Crusader Showroom, Orison"
+      ]
+    },
+    "RSI_Meteor": {
+      "name": "Meteor",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 0,
+        "speed": {
+          "max": 1405,
+          "scm": 229,
+          "roll": 155,
+          "pitch": 46,
+          "yaw": 38
+        },
+        "emission": {
+          "ir": 8560,
+          "em_idle": 7880,
+          "em_max": 23562
+        },
+        "fuel": {
+          "quantum": 1.15,
+          "hydro": 28.95
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "kron_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "kron_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "rsi_ballisticcannon_s5_meteor_bespoke"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "rsi_ballisticcannon_s5_meteor_bespoke"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "kron_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "kron_lasercannon_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 4,
+          "count": 4,
+          "missle-class": "misl_s04_em_taln_raptor"
+        },
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_em_taln_dominator"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "dbr body underside fin (right)": 150,
+        "dbr body underside fin (left)": 150,
+        "dbr small fin (left)": 150,
+        "dbr small fin (right)": 150,
+        "body main": 2750,
+        "body diffuser (rear)": 200,
+        "nose wingmount (left)": 1050,
+        "body main underside torp bay": 200,
+        "body main spine": 200,
+        "main rear connector (tail)": 200,
+        "dbr body spine side fin left (top)": 150,
+        "dbr body spine side fin right (top)": 150,
+        "main exhaust housing (tail)": 200,
+        "dbr body cap inner left (rear)": 150,
+        "dbr body cap inner right (rear)": 150,
+        "dbr body cap outer right (rear)": 150,
+        "dbr body cap outer left (rear)": 150,
+        "tail": 200,
+        "glass ext": 200,
+        "wing (left)": 200,
+        "dbr wing cover inner left (top)": 150,
+        "dbr side inner fin left (top)": 150,
+        "dbr wing left (tail)": 4000,
+        "engine connector left (tail)": 1000,
+        "dbr engine (left)": 2800,
+        "engines base (left)": 2800,
+        "wing (right)": 200,
+        "dbr wing cover inner right (top)": 150,
+        "dbr side inner fin right (top)": 150,
+        "dbr wing right (tail)": 4000,
+        "engine connector right (tail)": 1000,
+        "dbr engine (right)": 2800,
+        "engines base (right)": 2800,
+        "body spine housing (mid)": 200,
+        "nose wingmount (right)": 1050
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          },
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s01_beacon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ARGO_MOLE": {
+      "name": "MOLE",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": 5130500,
+        "crew": 5,
+        "cargo": 96,
+        "stowage": 4570000,
+        "speed": {
+          "max": 960,
+          "scm": 140,
+          "roll": 75,
+          "pitch": 30,
+          "yaw": 30
+        },
+        "emission": {
+          "ir": 14399,
+          "em_idle": 41410,
+          "em_max": 76712
+        },
+        "fuel": {
+          "quantum": 2.6,
+          "hydro": 200
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "front": 22575,
+        "thruster vtol right (front)": 1200,
+        "thruster vtol left (front)": 1200,
+        "rear": 45000,
+        "thruster bot (right)": 2000,
+        "thruster (top right)": 2000,
+        "vtol (rear right)": 1200,
+        "thruster bot (left)": 2000,
+        "thruster (top left)": 2000,
+        "vtol (rear left)": 1200
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_behr_s03_5ca_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s03_ginzel_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s03_thermalcore_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s02_huracan_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "ARGO_MPUV": {
+      "name": "MPUV Cargo",
+      "stats": {
+        "ship-size": "snub",
+        "purchase-price": 224200,
+        "crew": 1,
+        "cargo": 2,
+        "stowage": 800000,
+        "speed": {
+          "max": 890,
+          "scm": 170,
+          "roll": 85,
+          "pitch": 30,
+          "yaw": 30
+        },
+        "emission": {
+          "ir": 7624,
+          "em_idle": 3861,
+          "em_max": 9187
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 3
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "nose": 2500,
+        "body": 2500,
+        "leg (right)": 240,
+        "hardpoint thruster (rear right top)": 50,
+        "hardpoint thruster middle (rear right)": 50,
+        "hardpoint thruster (rear right bottom)": 50,
+        "hardpoint engine (right)": 50,
+        "leg (left)": 240,
+        "hardpoint thruster (rear left bottom)": 50,
+        "hardpoint thruster middle (rear left)": 50,
+        "hardpoint thruster (rear left top)": 50,
+        "hardpoint engine (left)": 50,
+        "cargo container exterior": 440,
+        "hardpoint thruster (front left bottom)": 50,
+        "hardpoint thruster (front right bottom)": 50,
+        "hardpoint thruster middle (front right)": 50,
+        "hardpoint thruster (front right top)": 50,
+        "hardpoint thruster (front right front)": 50,
+        "hardpoint thruster middle (front left)": 50,
+        "hardpoint thruster (front left top)": 50,
+        "hardpoint thruster (front left front)": 50,
+        "hardpoint engine middle (right)": 50,
+        "hardpoint engine middle (left)": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_ionwave_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          },
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "ARGO_MPUV_Transport": {
+      "name": "MPUV Personnel",
+      "stats": {
+        "ship-size": "snub",
+        "purchase-price": 233000,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 710000,
+        "speed": {
+          "max": 890,
+          "scm": 170,
+          "roll": 85,
+          "pitch": 30,
+          "yaw": 30
+        },
+        "emission": {
+          "ir": 7528,
+          "em_idle": 3861,
+          "em_max": 9186
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 3
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "nose": 2500,
+        "body": 2500,
+        "leg (right)": 240,
+        "hardpoint thruster (rear right top)": 50,
+        "hardpoint thruster middle (rear right)": 50,
+        "hardpoint thruster (rear right bottom)": 50,
+        "hardpoint engine (right)": 50,
+        "leg (left)": 240,
+        "hardpoint thruster (rear left bottom)": 50,
+        "hardpoint thruster middle (rear left)": 50,
+        "hardpoint thruster (rear left top)": 50,
+        "hardpoint engine (left)": 50,
+        "aegs escape pod exterior": 440,
+        "hardpoint thruster (front left bottom)": 50,
+        "hardpoint thruster (front right bottom)": 50,
+        "hardpoint thruster middle (front right)": 50,
+        "hardpoint thruster (front right top)": 50,
+        "hardpoint thruster (front right front)": 50,
+        "hardpoint thruster middle (front left)": 50,
+        "hardpoint thruster (front left top)": 50,
+        "hardpoint thruster (front left front)": 50,
+        "hardpoint engine middle (right)": 50,
+        "hardpoint engine middle (left)": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_ionwave_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          },
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "ARGO_MPUV_1T": {
+      "name": "MPUV Tractor",
+      "stats": {
+        "ship-size": "snub",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 16,
+        "stowage": 2450000,
+        "speed": {
+          "max": 895,
+          "scm": 175,
+          "roll": 85,
+          "pitch": 35,
+          "yaw": 35
+        },
+        "emission": {
+          "ir": 8329,
+          "em_idle": 4039,
+          "em_max": 9542
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 3
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        }
+      ],
+      "health": {
+        "body": 2500,
+        "nose": 2500,
+        "hardpoint thruster (front right bottom)": 50,
+        "hardpoint thruster (front left bottom)": 50,
+        "headlight bot l": 200,
+        "headlight l (top)": 200,
+        "headlight r (top)": 200,
+        "headlight bot r": 200,
+        "cooler cap mesh": 50,
+        "power cap mesh": 50,
+        "leg (right)": 240,
+        "hardpoint thruster (rear right top)": 50,
+        "hardpoint thruster middle (rear right)": 50,
+        "hardpoint thruster (rear right bottom)": 50,
+        "hardpoint engine (right)": 50,
+        "leg (left)": 240,
+        "hardpoint thruster (rear left bottom)": 50,
+        "hardpoint thruster middle (rear left)": 50,
+        "hardpoint thruster (rear left top)": 50,
+        "hardpoint engine (left)": 50,
+        "hardpoint thruster middle (front right)": 50,
+        "hardpoint thruster (front right top)": 50,
+        "hardpoint thruster (front right front)": 50,
+        "hardpoint thruster middle (front left)": 50,
+        "hardpoint thruster (front left top)": 50,
+        "hardpoint thruster (front left front)": 50,
+        "hardpoint engine middle (right)": 50,
+        "hardpoint engine middle (left)": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_ionwave_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "GRIN_MTC": {
+      "name": "MTC",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 0,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 1935,
+          "em_idle": 1876,
+          "em_max": 14114
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 23.625
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "body": 14500,
+        "head light sheild (left)": 80,
+        "head light sheild (right)": 80,
+        "light sheild right (rear)": 80,
+        "bar (front left)": 200,
+        "bar cover (front left)": 100,
+        "fender (left)": 300,
+        "fender light (left)": 100,
+        "bar (front)": 250,
+        "light sheild left (rear)": 200,
+        "fender (right)": 300,
+        "fender light (right)": 100,
+        "roof (front)": 400,
+        "bar (front right)": 200,
+        "bar cover (front right)": 100
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s00_defiant_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_cryostarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "DRAK_Mule": {
+      "name": "Mule",
+      "stats": {
+        "ship-size": "undefined",
+        "purchase-price": 15000,
+        "crew": 1,
+        "cargo": 1,
+        "stowage": 730000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 1752,
+          "em_idle": 1305,
+          "em_max": 13198
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "seat hatch": 200,
+        "door arms": 200,
+        "entry door node (upper)": 200,
+        "entry door (lower)": 200,
+        "arm hinge": 200,
+        "cargo arms": 200,
+        "shield sdf 01 ft": 200,
+        "body": 2000,
+        "rear": 2000,
+        "sidetray (left)": 200,
+        "sidetray (right)": 200,
+        "hardpoint wheel rl": 800,
+        "hardpoint wheel rr": 800,
+        "hardpoint wheel mr": 800,
+        "hardpoint wheel fr": 800,
+        "hardpoint wheel ml": 800,
+        "hardpoint wheel fl": 800
+      },
+      "components": {
+        "shields": [],
+        "power-plants": [
+          {
+            "class": "powr_just_s00_steadfast_scitem"
+          },
+          {
+            "class": "powr_just_s00_steadfast_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_winterstarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "CNOU_Mustang_Alpha": {
+      "name": "Mustang Alpha",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 251400,
+        "crew": 1,
+        "cargo": 4,
+        "stowage": 1900000,
+        "speed": {
+          "max": 1218,
+          "scm": 228,
+          "roll": 205,
+          "pitch": 70,
+          "yaw": 53
+        },
+        "emission": {
+          "ir": 7015,
+          "em_idle": 6783,
+          "em_max": 21209
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 6
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 1900,
+        "nacelle (right)": 1200,
+        "small wing (right)": 150,
+        "wing (right)": 800,
+        "wing part02 (right)": 800,
+        "wing part03 (right)": 150,
+        "nacelle (left)": 1200,
+        "small wing (left)": 150,
+        "wing (left)": 800,
+        "wing part02 (left)": 800,
+        "wing part03 (left)": 150,
+        "nose": 1900,
+        "cockpit glass frame": 80
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s01_ink_scitem"
+          },
+          {
+            "class": "shld_seco_s01_ink_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s01_zapjet_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s01_winterstar_scitem"
+          },
+          {
+            "class": "cool_jspn_s01_winterstar_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_arcc_s01_rush_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Traveler Rentals, Area 18",
+        "Traveler Rentals, Orison",
+        "Vantage Rentals, Lorville"
+      ]
+    },
+    "CNOU_Mustang_Alpha_CitizenCon2018": {
+      "name": "Mustang Alpha Vindicator",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 4,
+        "stowage": 1900000,
+        "speed": {
+          "max": 1218,
+          "scm": 228,
+          "roll": 205,
+          "pitch": 70,
+          "yaw": 53
+        },
+        "emission": {
+          "ir": 7015,
+          "em_idle": 6783,
+          "em_max": 21209
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 6
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 1900,
+        "nacelle (right)": 1200,
+        "small wing (right)": 150,
+        "wing (right)": 800,
+        "wing part02 (right)": 800,
+        "wing part03 (right)": 150,
+        "nacelle (left)": 1200,
+        "small wing (left)": 150,
+        "wing (left)": 800,
+        "wing part02 (left)": 800,
+        "wing part03 (left)": 150,
+        "nose": 1900,
+        "cockpit glass frame": 80
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s01_ink_scitem"
+          },
+          {
+            "class": "shld_seco_s01_ink_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s01_zapjet_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s01_winterstar_scitem"
+          },
+          {
+            "class": "cool_jspn_s01_winterstar_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_arcc_s01_rush_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "CNOU_Mustang_Beta": {
+      "name": "Mustang Beta",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 404000,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 2120000,
+        "speed": {
+          "max": 1218,
+          "scm": 228,
+          "roll": 205,
+          "pitch": 70,
+          "yaw": 53
+        },
+        "emission": {
+          "ir": 7015,
+          "em_idle": 6783,
+          "em_max": 22543
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 8
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 1900,
+        "nacelle (right)": 1200,
+        "small wing (right)": 150,
+        "wing (right)": 800,
+        "wing part02 (right)": 800,
+        "wing part03 (right)": 150,
+        "nacelle (left)": 1200,
+        "small wing (left)": 150,
+        "wing (left)": 800,
+        "wing part02 (left)": 800,
+        "wing part03 (left)": 150,
+        "nose": 1900,
+        "cockpit glass frame": 80
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s01_ink_scitem"
+          },
+          {
+            "class": "shld_seco_s01_ink_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s01_roughneck_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s01_hydrocel_scitem"
+          },
+          {
+            "class": "cool_just_s01_hydrocel_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_arcc_s01_rush_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "CNOU_Mustang_Delta": {
+      "name": "Mustang Delta",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 763600,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1600000,
+        "speed": {
+          "max": 1195,
+          "scm": 226,
+          "roll": 202,
+          "pitch": 69,
+          "yaw": 52
+        },
+        "emission": {
+          "ir": 7855,
+          "em_idle": 9479,
+          "em_max": 28135
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 7.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 1900,
+        "nacelle (right)": 1200,
+        "small wing (right)": 150,
+        "wing (right)": 800,
+        "wing part02 (right)": 800,
+        "wing part03 (right)": 150,
+        "nacelle (left)": 1200,
+        "small wing (left)": 150,
+        "wing (left)": 800,
+        "wing part02 (left)": 800,
+        "wing part03 (left)": 150,
+        "nose": 1900,
+        "cockpit glass frame": 80
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_securehyde_scitem"
+          },
+          {
+            "class": "shld_godi_s01_securehyde_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_amrs_s01_overdrive_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s01_winterstar_scitem"
+          },
+          {
+            "class": "cool_jspn_s01_winterstar_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_arcc_s01_rush_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "CNOU_Mustang_Gamma": {
+      "name": "Mustang Gamma",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 627500,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1600000,
+        "speed": {
+          "max": 1230,
+          "scm": 244,
+          "roll": 235,
+          "pitch": 84,
+          "yaw": 65
+        },
+        "emission": {
+          "ir": 7773,
+          "em_idle": 7249,
+          "em_max": 21609
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 6
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        }
+      ],
+      "missles": [],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 1750,
+        "nacelle (right)": 1200,
+        "small wing (right)": 150,
+        "wing (right)": 500,
+        "wing part02 (right)": 500,
+        "wing part03 (right)": 150,
+        "nacelle (left)": 1200,
+        "small wing (left)": 150,
+        "wing (left)": 500,
+        "wing part02 (left)": 500,
+        "wing part03 (left)": 150,
+        "nose": 1750,
+        "cockpit glass frame": 80
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_yorm_s01_falco_scitem"
+          },
+          {
+            "class": "shld_yorm_s01_falco_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_acom_s01_lumacore_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_acom_s01_quickcool_scitem"
+          },
+          {
+            "class": "cool_acom_s01_quickcool_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_arcc_s01_rush_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18",
+        "Traveler Rentals, Area 18",
+        "Traveler Rentals, Orison"
+      ]
+    },
+    "CNOU_Mustang_Omega": {
+      "name": "Mustang Omega",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1600000,
+        "speed": {
+          "max": 1230,
+          "scm": 244,
+          "roll": 235,
+          "pitch": 84,
+          "yaw": 65
+        },
+        "emission": {
+          "ir": 7773,
+          "em_idle": 7249,
+          "em_max": 21609
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 6
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        }
+      ],
+      "missles": [],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 1750,
+        "nacelle (right)": 1200,
+        "small wing (right)": 150,
+        "wing (right)": 500,
+        "wing part02 (right)": 500,
+        "wing part03 (right)": 150,
+        "nacelle (left)": 1200,
+        "small wing (left)": 150,
+        "wing (left)": 500,
+        "wing part02 (left)": 500,
+        "wing part03 (left)": 150,
+        "nose": 1750,
+        "cockpit glass frame": 80
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_yorm_s01_falco_scitem"
+          },
+          {
+            "class": "shld_yorm_s01_falco_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_acom_s01_lumacore_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_acom_s01_quickcool_scitem"
+          },
+          {
+            "class": "cool_acom_s01_quickcool_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_arcc_s01_rush_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "CNOU_Nomad": {
+      "name": "Nomad",
+      "stats": {
+        "ship-size": "undefined",
+        "purchase-price": 952800,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1230000,
+        "speed": {
+          "max": 1100,
+          "scm": 205,
+          "roll": 120,
+          "pitch": 45,
+          "yaw": 45
+        },
+        "emission": {
+          "ir": 7626,
+          "em_idle": 6416,
+          "em_max": 21139
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 32.8
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 8,
+          "missle-class": "misl_s02_cs_thcn_strikeforce"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 4000,
+        "vertical stabilizer (right top)": 50,
+        "vertical stabilizer (left top)": 50,
+        "vertical stabilizer (left bottom)": 50,
+        "vertical stabilizer (right bottom)": 50,
+        "nose": 4000,
+        "wing (right)": 500,
+        "canopy": 200,
+        "wing (left)": 500,
+        "vertical stabilizer (left)": 200,
+        "vertical stabilizer (right)": 200
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s01_web_scitem"
+          },
+          {
+            "class": "shld_seco_s01_web_scitem"
+          },
+          {
+            "class": "shld_seco_s01_web_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s01_ionburst_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s01_ultraflow_scitem"
+          },
+          {
+            "class": "cool_just_s01_ultraflow_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s01_expedition_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "TMBL_Nova": {
+      "name": "Nova",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": 515200,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 3170000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 2732,
+          "em_idle": 3263,
+          "em_max": 16553
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "hrst_nova_ballisticcannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "tmbl nova": 40000,
+        "body mesh": 40000,
+        "hardpoint wheel hidden rear 09 (right)": 800,
+        "hardpoint wheel hidden front 08 (right)": 800,
+        "hardpoint wheel hidden front 08 (left)": 800,
+        "hardpoint wheel hidden rear 09 (left)": 800,
+        "hardpoint wheel 01 (left)": 800,
+        "hardpoint wheel 02 (left)": 800,
+        "hardpoint wheel 03 (left)": 800,
+        "hardpoint wheel 04 (left)": 800,
+        "hardpoint wheel 05 (left)": 800,
+        "hardpoint wheel 06 (left)": 800,
+        "hardpoint wheel 07 (left)": 800,
+        "hardpoint wheel 01 (right)": 800,
+        "hardpoint wheel 02 (right)": 800,
+        "hardpoint wheel 03 (right)": 800,
+        "hardpoint wheel 04 (right)": 800,
+        "hardpoint wheel 05 (right)": 800,
+        "hardpoint wheel 06 (right)": 800,
+        "hardpoint wheel 07 (right)": 800,
+        "primary turret debris": 30000,
+        "hardpoint wheel small (left)": 800,
+        "hardpoint drive sprocket (left)": 800,
+        "hardpoint wheel small (right)": 800,
+        "hardpoint drive sprocket (right)": 800
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          },
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          },
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          },
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          },
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          },
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "XIAN_Nox": {
+      "name": "Nox",
+      "stats": {
+        "ship-size": "snub",
+        "purchase-price": 349200,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 690000,
+        "speed": {
+          "max": 619,
+          "scm": 225,
+          "roll": 138,
+          "pitch": 89,
+          "yaw": 89
+        },
+        "emission": {
+          "ir": 1551,
+          "em_idle": 2002,
+          "em_max": 14174
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 1.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "nacelle r (rear)": 320,
+        "$physics proxy nacelle r (rear)": 1,
+        "nacelle l (rear)": 320,
+        "$physics proxy nacelle l (rear)": 1,
+        "body (back)": 400,
+        "body (front)": 120,
+        "nose": 440,
+        "cowling (front)": 225,
+        "dmg nose": 1,
+        "$physics proxy nose": 1,
+        "dmg body (front)": 1,
+        "$physics proxy body (front)": 1,
+        "dmg body (back)": 200,
+        "$physics proxy body (back)": 200
+      },
+      "components": {
+        "shields": [],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_wcpr_s00_fridan_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18",
+        "Traveler Rentals, Area 18",
+        "Traveler Rentals, Orison",
+        "Regal Luxury Rentals, New Babbage"
+      ]
+    },
+    "XIAN_Nox_Kue": {
+      "name": "Nox Kue",
+      "stats": {
+        "ship-size": "snub",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 690000,
+        "speed": {
+          "max": 619,
+          "scm": 225,
+          "roll": 138,
+          "pitch": 89,
+          "yaw": 89
+        },
+        "emission": {
+          "ir": 1531,
+          "em_idle": 1966,
+          "em_max": 14138
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 1.5
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "nacelle r (rear)": 320,
+        "$physics proxy nacelle r (rear)": 1,
+        "nacelle l (rear)": 320,
+        "$physics proxy nacelle l (rear)": 1,
+        "body (back)": 400,
+        "body (front)": 120,
+        "nose": 440,
+        "cowling (front)": 225,
+        "dmg nose": 1,
+        "$physics proxy nose": 1,
+        "dmg body (front)": 1,
+        "$physics proxy body (front)": 1,
+        "dmg body (back)": 200,
+        "$physics proxy body (back)": 200
+      },
+      "components": {
+        "shields": [],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_wcpr_s00_fridan_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "KRIG_P52_Merlin": {
+      "name": "P-52 Merlin",
+      "stats": {
+        "ship-size": "snub",
+        "purchase-price": 135500,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 860000,
+        "speed": {
+          "max": 1450,
+          "scm": 280,
+          "roll": 200,
+          "pitch": 55,
+          "yaw": 55
+        },
+        "emission": {
+          "ir": 7474,
+          "em_idle": 4769,
+          "em_max": 18572
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 7
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "wing animation geo (right)": 200,
+        "wing animation geo (left)": 200,
+        "body": 1000,
+        "body2": 1000,
+        "canopy": 80
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_securehyde_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_sasu_s01_lightblossom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s01_froststar_scitem"
+          },
+          {
+            "class": "cool_jspn_s01_froststar_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "KRIG_P72_Archimedes": {
+      "name": "P-72 Archimedes",
+      "stats": {
+        "ship-size": "snub",
+        "purchase-price": 150000,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 860000,
+        "speed": {
+          "max": 1485,
+          "scm": 300,
+          "roll": 190,
+          "pitch": 50,
+          "yaw": 50
+        },
+        "emission": {
+          "ir": 7769,
+          "em_idle": 6955,
+          "em_max": 21728
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 7
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "wing animation geo (left)": 200,
+        "wing animation geo (right)": 200,
+        "body": 800,
+        "body2": 800,
+        "canopy": 80
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_yorm_s01_targa_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_charger_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "KRIG_P72_Archimedes_Emerald": {
+      "name": "P-72 Archimedes Emerald",
+      "stats": {
+        "ship-size": "snub",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 860000,
+        "speed": {
+          "max": 1485,
+          "scm": 300,
+          "roll": 190,
+          "pitch": 50,
+          "yaw": 50
+        },
+        "emission": {
+          "ir": 7769,
+          "em_idle": 6955,
+          "em_max": 21728
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 7
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "wing animation geo (right)": 200,
+        "wing animation geo (left)": 200,
+        "body": 800,
+        "body2": 800,
+        "canopy": 80
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_yorm_s01_targa_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_charger_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "RSI_Polaris": {
+      "name": "Polaris",
+      "stats": {
+        "ship-size": "capital",
+        "purchase-price": null,
+        "crew": 12,
+        "cargo": 576,
+        "stowage": 432000000,
+        "speed": {
+          "max": 940,
+          "scm": 145,
+          "roll": 14,
+          "pitch": 10,
+          "yaw": 8
+        },
+        "emission": {
+          "ir": 29029,
+          "em_idle": 16754,
+          "em_max": 86894
+        },
+        "fuel": {
+          "quantum": 12.6,
+          "hydro": 1100
+        }
+      },
+      "weapons": [
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "rsi_polaris_turret_front"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "rsi_polaris_turret_side_left"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "rsi_polaris_turret_side_right"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "rsi_polaris_turret_top_left"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "rsi_polaris_turret_top_right"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 16,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        },
+        {
+          "size": 10,
+          "count": 28,
+          "missle-class": "misl_s10_ir_behr_torpedo"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 30,
+          "name": "Joker Defcon Flares Ammo"
+        },
+        {
+          "type": "decoy",
+          "count": 30,
+          "name": "Joker Defcon Flares Ammo"
+        },
+        {
+          "type": "noise",
+          "count": 15,
+          "name": "Joker Defcon - Noise Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 15,
+          "name": "Joker Defcon - Noise Launcher"
+        },
+        {
+          "type": "decoy",
+          "count": 30,
+          "name": "Joker Defcon Flares Ammo"
+        },
+        {
+          "type": "decoy",
+          "count": 30,
+          "name": "Joker Defcon Flares Ammo"
+        }
+      ],
+      "health": {
+        "m det mesh thruster base bot left (rear)": 45000,
+        "m det mesh thruster cap bot left (rear)": 10000,
+        "m det mesh thruster base bot right (rear)": 45000,
+        "m det mesh thruster cap bot right (rear)": 10000,
+        "m det mesh thruster base top left (rear)": 45000,
+        "det mesh thruster cap top left (rear)": 10000,
+        "m det mesh thruster base top right (rear)": 45000,
+        "m det mesh thruster cap top right (rear)": 10000,
+        "m det mesh thruster fin tip bot left (rear)": 1000,
+        "m det mesh thruster fin tip bot right (rear)": 1000,
+        "m det mesh thruster fin tip top left (rear)": 1000,
+        "m det mesh thruster fin tip top right (rear)": 1000,
+        "m det neck aileron tip left (front)": 1000,
+        "m det neck aileron rotator left (front)": 500,
+        "m det neck aileron tip right (front)": 1000,
+        "m det neck aileron rotator right (front)": 500,
+        "mesh det airbrake tip (top right)": 1000,
+        "mesh det airbrake tip (top left)": 1000,
+        "mesh det airbrake tip bot (right)": 1000,
+        "mesh det airbrake tip bot (left)": 1000,
+        "mesh det aileron tip bot right (rear)": 1000,
+        "mesh det aileron fin bot right (rear)": 500,
+        "mesh det aileron tip top right (rear)": 1000,
+        "mesh det aileron fin top right (rear)": 500,
+        "mesh det aileron tip bot left (rear)": 1000,
+        "mesh det aileron fin bot left (rear)": 500,
+        "mesh det aileron tip top left (rear)": 1000,
+        "mesh det aileron fin top left (rear)": 500,
+        "body lg hatch rear r left (front)": 200,
+        "body lg hatch rear l right (front)": 200,
+        "body lg hatch rear l left (front)": 200,
+        "m body": 918000,
+        "m (rear)": 1200000,
+        "m det mesh thruster housing middle (right)": 60000,
+        "m det mesh thruster housing middle (left)": 60000,
+        "m neck (rear)": 720000,
+        "m neck (front)": 440000,
+        "m nose": 220000,
+        "m det escpod 01 (left)": 500,
+        "m det escpod 01 (right)": 500,
+        "m det escpod 02 (left)": 500,
+        "m det escpod 02 (right)": 500,
+        "m det escpod 03 (left)": 500,
+        "m det escpod 03 (right)": 500,
+        "m det escpod 04 (left)": 500,
+        "m det escpod 04 (right)": 500,
+        "m det neck hatch static (front)": 1000,
+        "m det neck side plate left (front)": 1000,
+        "m det neck side plate right (front)": 1000,
+        "m det neck side cover left (front top)": 1000,
+        "m det neck side cover right (front top)": 1000,
+        "m det nose side de (tail left)": 5000,
+        "m det nose side de (tail right)": 5000,
+        "m det nose cover panel (top)": 2500,
+        "m det neck vent left (rear)": 2500,
+        "m det neck vent right (rear)": 2500,
+        "m det body side panel (right)": 1000,
+        "m det body side panel (left)": 1000,
+        "m det turret hatch slide (top right)": 3000,
+        "m det turret hatch slide (top left)": 3000,
+        "m det turret hatch slide (bottom right)": 2500,
+        "m det turret hatch slide (bottom left)": 2500,
+        "m det turret hatch (top right)": 5000,
+        "m det turret hatch (top left)": 5000,
+        "m det turret hatch (bottom right)": 5000,
+        "m det turret hatch (bottom left)": 5000,
+        "m det body airbrakepanel bot (left)": 10000,
+        "m det body airbrakepanel bot (right)": 10000,
+        "m det body airbrakepanel (top left)": 1000,
+        "m det body airbrakepanel (top right)": 1000,
+        "m det body underside plate": 10000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_rsi_s04_polaris_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_rsi_s04_polaris_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_rsi_s04_polaris_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s03_erebos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "MISC_Prospector": {
+      "name": "Prospector",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 2061000,
+        "crew": 1,
+        "cargo": 32,
+        "stowage": 930000,
+        "speed": {
+          "max": 994,
+          "scm": 156,
+          "roll": 75,
+          "pitch": 35,
+          "yaw": 35
+        },
+        "emission": {
+          "ir": 9033,
+          "em_idle": 18351,
+          "em_max": 40547
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 21
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "nose": 13800,
+        "rear": 13800,
+        "hardpoint thruster main (rear left)": 50,
+        "hardpoint landinggear (right)": 200,
+        "hardpoint landinggear (left)": 200,
+        "pipes (rear)": 400,
+        "coupling rr": 100,
+        "coupling rl": 100,
+        "hardpoint thruster main (rear right)": 50,
+        "hardpoint fuel intake": 50,
+        "hardpoint fuel tank": 50,
+        "hardpoint thruster main middle (rear)": 50,
+        "hardpoint landinggear (front)": 200,
+        "nose pipes": 400,
+        "coupling fl": 1000,
+        "basket l": 1000,
+        "coupling fr": 1000,
+        "basket r": 1000,
+        "hardpoint thruster retro (right)": 10,
+        "hardpoint thruster retro (left)": 10
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          },
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          },
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s02_trommel_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s02_snowfall_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s01_goliath_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Vantage Rentals, CRU-L1",
+        "Vantage Rentals, ARC-L1",
+        "Vantage Rentals, HUR-L1",
+        "Vantage Rentals, HUR-L2",
+        "Vantage Rentals, MIC-L2"
+      ]
+    },
+    "ESPR_Prowler": {
+      "name": "Prowler",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": 4248200,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1850000,
+        "speed": {
+          "max": 1200,
+          "scm": 212,
+          "roll": 110,
+          "pitch": 38,
+          "yaw": 32
+        },
+        "emission": {
+          "ir": 20492,
+          "em_idle": 26224,
+          "em_max": 55580
+        },
+        "fuel": {
+          "quantum": 2,
+          "hydro": 39
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "espr_ballisticcannon_s5"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "espr_ballisticcannon_s5"
+        }
+      ],
+      "missles": [],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "nose": 12500,
+        "humerus (right)": 6500,
+        "ulna (right)": 6500,
+        "phalange shield (right)": 700,
+        "humerus base e (right)": 3500,
+        "humerus (left)": 6500,
+        "ulna (left)": 6500,
+        "phalange shield (left)": 700,
+        "humerus base e (left)": 3500,
+        "body": 22000,
+        "wing stabilizer left (rear)": 4000,
+        "wing stabilizer right (rear)": 4000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s02_obscura_scitem"
+          },
+          {
+            "class": "shld_asas_s02_obscura_scitem"
+          },
+          {
+            "class": "shld_asas_s02_obscura_scitem"
+          },
+          {
+            "class": "shld_asas_s02_obscura_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_tydt_s02_eclipse_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_tydt_s02_heatsink_scitem"
+          },
+          {
+            "class": "cool_tydt_s02_heatsink_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_raco_s02_nova_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ESPR_Prowler_Utility": {
+      "name": "Prowler Utility",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 32,
+        "stowage": 0,
+        "speed": {
+          "max": 1110,
+          "scm": 208,
+          "roll": 100,
+          "pitch": 35,
+          "yaw": 30
+        },
+        "emission": {
+          "ir": 21292,
+          "em_idle": 25761,
+          "em_max": 55207
+        },
+        "fuel": {
+          "quantum": 2.25,
+          "hydro": 43
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "espr_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "espr_lasercannon_s4"
+        }
+      ],
+      "missles": [],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "nose": 10500,
+        "humerus (right)": 6000,
+        "ulna (right)": 6000,
+        "geo phalange d (right)": 300,
+        "geo phalange c (right)": 300,
+        "geo phalange b (right)": 300,
+        "geo phalange a (right)": 300,
+        "humerus base e (right)": 3500,
+        "humerus (left)": 6000,
+        "ulna (left)": 6000,
+        "geo phalange d (left)": 300,
+        "geo phalange c (left)": 300,
+        "geo phalange b (left)": 300,
+        "geo phalange a (left)": 300,
+        "humerus base e (left)": 3500,
+        "body": 18000,
+        "wing stabilizer left (rear)": 2500,
+        "geo wing vertical stabilizer left (rear)": 600,
+        "geo wing vertical stabilizer extra left (rear)": 600,
+        "wing stabilizer right (rear)": 2500,
+        "geo wing vertical stabilizer right (rear)": 600,
+        "geo wing vertical stabilizer extra right (rear)": 600
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s02_obscura_scitem"
+          },
+          {
+            "class": "shld_asas_s02_obscura_scitem"
+          },
+          {
+            "class": "shld_asas_s02_obscura_scitem"
+          },
+          {
+            "class": "shld_asas_s02_obscura_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_tydt_s02_eclipse_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_tydt_s02_heatsink_scitem"
+          },
+          {
+            "class": "cool_tydt_s02_heatsink_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_raco_s02_nova_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "GRIN_PTV": {
+      "name": "PTV",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": 5000,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 2540000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 369,
+          "em_idle": 30,
+          "em_max": 137
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 1
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "grin ptv": 1500,
+        "reverselight (left)": 200,
+        "reverselight (right)": 200,
+        "brakelightflare (left)": 200,
+        "brakelight (left)": 200,
+        "brakelightflare (right)": 200,
+        "brakelight (right)": 200,
+        "headlightflare (left)": 200,
+        "headlight (left)": 200,
+        "headlightflare (right)": 200,
+        "headlight (right)": 200,
+        "body": 1200,
+        "glass": 200,
+        "glass 100 debris1": 1,
+        "glass 100 debris2": 1,
+        "body 100 debris steering": 1,
+        "body 100 debris3": 1,
+        "body 100 debris wheel2": 1,
+        "body 100 debris2": 1,
+        "body 100 debris wheel1": 1,
+        "body 100 debris wheel4": 1,
+        "body 100 debris1": 1,
+        "body 100 debris wheel3": 1,
+        "wheel3": 900,
+        "wheel4": 900,
+        "wheel2": 900,
+        "wheel1": 900
+      },
+      "components": {
+        "shields": [],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "MRAI_Pulse": {
+      "name": "Pulse",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 850000,
+        "speed": {
+          "max": 561,
+          "scm": 204,
+          "roll": 135,
+          "pitch": 84,
+          "yaw": 84
+        },
+        "emission": {
+          "ir": 2115,
+          "em_idle": 1771,
+          "em_max": 13673
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0.65
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "toag_lasergatling_s2"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "body": 700,
+        "body spoiler mesh (upper left)": 50,
+        "component housing mesh": 50,
+        "hardpoint vehicle destroyed": 400,
+        "body spoiler mesh (upper right)": 50,
+        "body panel debris (back right)": 50,
+        "body panel debris (back left)": 50,
+        "arm debris a (front right)": 50,
+        "arm debris a panel (front right)": 50,
+        "arm debris a (front left)": 50,
+        "arm debris a panel (front left)": 50
+      },
+      "components": {
+        "shields": [],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_wcpr_s00_fridan_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "MRAI_Pulse_LX": {
+      "name": "Pulse LX",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 850000,
+        "speed": {
+          "max": 600,
+          "scm": 218,
+          "roll": 145,
+          "pitch": 97,
+          "yaw": 97
+        },
+        "emission": {
+          "ir": 2020,
+          "em_idle": 1486,
+          "em_max": 13388
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0.65
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "body": 700,
+        "body spoiler mesh (upper left)": 50,
+        "component housing mesh": 50,
+        "hardpoint vehicle destroyed": 400,
+        "body spoiler mesh (upper right)": 50,
+        "body panel debris (back right)": 50,
+        "body panel debris (back left)": 50,
+        "arm debris a (front right)": 50,
+        "arm debris a panel (front right)": 50,
+        "arm debris a (front left)": 50,
+        "arm debris a panel (front left)": 50
+      },
+      "components": {
+        "shields": [],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_wcpr_s00_fridan_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ARGO_RAFT": {
+      "name": "RAFT",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": 1853000,
+        "crew": 2,
+        "cargo": 192,
+        "stowage": 2460000,
+        "speed": {
+          "max": 990,
+          "scm": 140,
+          "roll": 117,
+          "pitch": 40,
+          "yaw": 40
+        },
+        "emission": {
+          "ir": 13709,
+          "em_idle": 15145,
+          "em_max": 52770
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 225
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        }
+      ],
+      "health": {
+        "front": 40717.7,
+        "rear left": 7500,
+        "argo raft rl vtol mesh": 250,
+        "argo raft rl lg mainshaft mesh": 250,
+        "argo raft fl vtol mesh": 250,
+        "argo raft fr vtol mesh": 250,
+        "rear right": 7500,
+        "argo raft rr vtol mesh": 1,
+        "argo raft rr lg mainshaft mesh": 250,
+        "argo raft fr lg mainshaft mesh": 250,
+        "argo raft fl lg mainshaft mesh": 250
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s02_aspis_scitem"
+          },
+          {
+            "class": "shld_basl_s02_aspis_scitem"
+          },
+          {
+            "class": "shld_basl_s02_aspis_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s02_diligence_scitem"
+          },
+          {
+            "class": "powr_just_s02_diligence_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s02_coolcore_scitem"
+          },
+          {
+            "class": "cool_just_s02_coolcore_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s02_bolon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "MISC_Razor": {
+      "name": "Razor",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1761200,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 860000,
+        "speed": {
+          "max": 1450,
+          "scm": 280,
+          "roll": 200,
+          "pitch": 55,
+          "yaw": 55
+        },
+        "emission": {
+          "ir": 7346,
+          "em_idle": 2083,
+          "em_max": 15119
+        },
+        "fuel": {
+          "quantum": 1,
+          "hydro": 3
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 2,
+          "missle-class": "misl_s01_ir_behr_marksman"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "hull (front)": 800,
+        "canopy (right)": 550,
+        "canopy (left)": 550,
+        "canopy (top)": 550,
+        "canopy (front)": 550,
+        "hull (rear)": 1700,
+        "wing (top)": 400,
+        "wing (rear right)": 600,
+        "wing (rear left)": 600,
+        "wing bridge (right)": 400,
+        "wing bridge (left)": 400,
+        "wing (front right)": 600,
+        "wing (front left)": 600
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_yorm_s01_targa_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_acom_s01_starheart_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_acom_s01_iceplunge_scitem"
+          },
+          {
+            "class": "cool_acom_s01_iceplunge_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_acas_s01_lightfire_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Vantage Rentals, Lorville"
+      ]
+    },
+    "MISC_Razor_EX": {
+      "name": "Razor EX",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1878800,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 860000,
+        "speed": {
+          "max": 1450,
+          "scm": 280,
+          "roll": 200,
+          "pitch": 55,
+          "yaw": 55
+        },
+        "emission": {
+          "ir": 9045,
+          "em_idle": 4954,
+          "em_max": 18757
+        },
+        "fuel": {
+          "quantum": 1,
+          "hydro": 3
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticscattergun_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "apar_ballisticscattergun_s2"
+        }
+      ],
+      "missles": [
+        {
+          "size": 1,
+          "count": 2,
+          "missle-class": "misl_s01_cs_fski_spark"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "hull (front)": 800,
+        "canopy (right)": 550,
+        "canopy (left)": 550,
+        "canopy (top)": 550,
+        "canopy (front)": 550,
+        "hull (rear)": 1700,
+        "wing (top)": 400,
+        "wing (rear right)": 600,
+        "wing (rear left)": 600,
+        "wing bridge (right)": 400,
+        "wing bridge (left)": 400,
+        "wing (front right)": 600,
+        "wing (front left)": 600
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_tydt_s01_soniclite_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_tydt_s01_heatsafe_scitem"
+          },
+          {
+            "class": "cool_tydt_s01_heatsafe_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_raco_s01_drift_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Astro Armada, Area 18"
+      ]
+    },
+    "MISC_Razor_LX": {
+      "name": "Razor LX",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1823800,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 860000,
+        "speed": {
+          "max": 1400,
+          "scm": 275,
+          "roll": 200,
+          "pitch": 55,
+          "yaw": 55
+        },
+        "emission": {
+          "ir": 8755,
+          "em_idle": 5383,
+          "em_max": 19099
+        },
+        "fuel": {
+          "quantum": 1,
+          "hydro": 3
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "hull (front)": 900,
+        "canopy (right)": 150,
+        "canopy (left)": 150,
+        "canopy (top)": 150,
+        "canopy (front)": 150,
+        "hull (rear)": 700,
+        "wing (top)": 100,
+        "wing (rear right)": 100,
+        "wing (rear left)": 100,
+        "wing bridge (right)": 100,
+        "wing bridge (left)": 100,
+        "wing (front right)": 100,
+        "wing (front left)": 100
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_yorm_s01_targa_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_acom_s01_starheart_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_acom_s01_iceplunge_scitem"
+          },
+          {
+            "class": "cool_acom_s01_iceplunge_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_acas_s01_lightfire_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Astro Armada, Area 18"
+      ]
+    },
+    "AEGS_Reclaimer": {
+      "name": "Reclaimer",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": 15126400,
+        "crew": 1,
+        "cargo": 420,
+        "stowage": 7220000,
+        "speed": {
+          "max": 870,
+          "scm": 110,
+          "roll": 14,
+          "pitch": 11,
+          "yaw": 11
+        },
+        "emission": {
+          "ir": 27145,
+          "em_idle": 19026,
+          "em_max": 47919
+        },
+        "fuel": {
+          "quantum": 8.6,
+          "hydro": 1754
+        }
+      },
+      "weapons": [
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "PDC Auto Turret",
+          "class": "turret_pdc_behr_a"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_reclaimer_scitem_turret"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "rear": 50000,
+        "bracket (left)": 1000,
+        "aux arms block (left)": 2000,
+        "aux arms a (top left)": 100,
+        "aux arms b (top left)": 100,
+        "aux arms b (lower left)": 100,
+        "aux arms (lower left bottom)": 100,
+        "bracket (right)": 1000,
+        "aux arms block (right)": 2000,
+        "aux arms a (top right)": 100,
+        "aux arms b (top right)": 100,
+        "aux arms b (lower right)": 100,
+        "aux arms (lower right bottom)": 100,
+        "front": 50000,
+        "arms vtol (lowerleft)": 200,
+        "arms (lowerleft)": 100,
+        "arms pistons left vtol (lower)": 200,
+        "arms pistons left (lower)": 100,
+        "arms vtol (lowerright)": 200,
+        "arms (lowerright)": 100,
+        "arms pistons right vtol (lower)": 200,
+        "arms pistons right (lower)": 100,
+        "arms block vtol (topleft)": 200,
+        "arms block (topleft)": 100,
+        "arms vtol (topleft)": 200,
+        "arms (topleft)": 100,
+        "arms pistons left vtol (top)": 200,
+        "arms pistons left (top)": 100,
+        "arms block vtol (topright)": 200,
+        "arms block (topright)": 100,
+        "arms vtol (topright)": 200,
+        "arms (topright)": 100,
+        "arms pistons right vtol (top)": 200,
+        "arms pistons right (top)": 100,
+        "main engine blockvtol (left)": 1,
+        "main engine block (left)": 2000,
+        "arms tip vtol (lowerleft)": 200,
+        "arms tip (lowerleft)": 100,
+        "arms tip vtol (topleft)": 200,
+        "arms tip (topleft)": 100,
+        "joint (left)": 2000,
+        "main engine (left)": 2000,
+        "main engine blockvtol (right)": 1,
+        "main engine block (right)": 2000,
+        "arms tip vtol (lowerright)": 200,
+        "arms tip (lowerright)": 100,
+        "arms tip vtol (topright)": 200,
+        "arms tip (topright)": 100,
+        "joint (right)": 2000,
+        "main engine (right)": 2000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_aegs_s04_reclaimer_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s04_reclaimer_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s04_reclaimer"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s03_kama_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "AEGS_Redeemer": {
+      "name": "Redeemer",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": 8675500,
+        "crew": 4,
+        "cargo": 2,
+        "stowage": 4220000,
+        "speed": {
+          "max": 1050,
+          "scm": 202.5,
+          "roll": 115,
+          "pitch": 34,
+          "yaw": 30
+        },
+        "emission": {
+          "ir": 16778,
+          "em_idle": 24629,
+          "em_max": 62971
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 66
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_redeemer_front_scitem_turret"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_redeemer_rear_scitem_turret"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_ballisticcannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_ballisticcannon_s4"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 16,
+          "missle-class": "misl_s02_cs_thcn_strikeforce"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 17000,
+        "tail": 3300,
+        "rudder (left)": 200,
+        "rudder flap (left)": 100,
+        "rudder (right)": 200,
+        "rudder flap (right)": 100,
+        "wing (left)": 5600,
+        "wing pitch (left)": 1000,
+        "wing debris (left bottom)": 5600,
+        "wing debris (left top)": 5600,
+        "wing (right)": 5600,
+        "wing pitch (right)": 1000,
+        "wing debris (right top)": 5600,
+        "wing debris (right bottom)": 5600,
+        "underbelly": 4500,
+        "nose": 5700
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s03_centurion_scitem"
+          },
+          {
+            "class": "powr_aegs_s03_centurion_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s03_blizzard_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s02_crossfield_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "MISC_Reliant": {
+      "name": "Reliant Kore",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 744700,
+        "crew": 1,
+        "cargo": 6,
+        "stowage": 2030000,
+        "speed": {
+          "max": 1150,
+          "scm": 218,
+          "roll": 140,
+          "pitch": 54,
+          "yaw": 43
+        },
+        "emission": {
+          "ir": 8806,
+          "em_idle": 3693,
+          "em_max": 17720
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 10.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 3500,
+        "engine (right)": 1180,
+        "engine (left)": 1180,
+        "nose": 3000,
+        "wing (right)": 3000,
+        "vertical stabilizer wing (bottom right)": 25,
+        "hardpoint thruster urs": 50,
+        "hardpoint thruster uls": 50,
+        "hardpoint thruster urr": 50,
+        "hardpoint thruster urf": 50,
+        "hardpoint thruster urb": 50,
+        "hardpoint thruster ull": 50,
+        "hardpoint thruster ulf": 50,
+        "hardpoint thruster ulb": 50,
+        "vertical stabilizer wing (top right)": 25,
+        "wing (left)": 3500,
+        "hardpoint thruster llb": 50,
+        "hardpoint thruster llf": 50,
+        "hardpoint thruster lll": 50,
+        "hardpoint thruster lrb": 50,
+        "hardpoint thruster lrf": 50,
+        "hardpoint thruster lrr": 50,
+        "hardpoint thruster lrs": 50,
+        "hardpoint thruster lls": 50,
+        "vertical stabilizer wing (bottom left)": 25,
+        "vertical stabilizer wing (top left)": 25
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s01_web_scitem"
+          },
+          {
+            "class": "shld_seco_s01_web_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s01_ionburst_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_lplt_s01_arcticstorm_scitem"
+          },
+          {
+            "class": "cool_lplt_s01_arcticstorm_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_arcc_s01_rush_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "MISC_Reliant_Mako": {
+      "name": "Reliant Mako",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 780000,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1680000,
+        "speed": {
+          "max": 1150,
+          "scm": 220,
+          "roll": 138,
+          "pitch": 54,
+          "yaw": 43
+        },
+        "emission": {
+          "ir": 9021,
+          "em_idle": 3082,
+          "em_max": 17015
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 10.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 3500,
+        "engine (right)": 1180,
+        "engine (left)": 1180,
+        "nose": 3000,
+        "wing (right)": 3000,
+        "vertical stabilizer wing (bottom right)": 25,
+        "hardpoint thruster urs": 50,
+        "hardpoint thruster uls": 50,
+        "hardpoint thruster urr": 50,
+        "hardpoint thruster urf": 50,
+        "hardpoint thruster urb": 50,
+        "hardpoint thruster ull": 50,
+        "hardpoint thruster ulf": 50,
+        "hardpoint thruster ulb": 50,
+        "vertical stabilizer wing (top right)": 25,
+        "wing (left)": 3500,
+        "hardpoint thruster llb": 50,
+        "hardpoint thruster llf": 50,
+        "hardpoint thruster lll": 50,
+        "hardpoint thruster lrb": 50,
+        "hardpoint thruster lrf": 50,
+        "hardpoint thruster lrr": 50,
+        "hardpoint thruster lrs": 50,
+        "hardpoint thruster lls": 50,
+        "vertical stabilizer wing (bottom left)": 25,
+        "vertical stabilizer wing (top left)": 25
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          },
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s01_ionburst_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_tydt_s01_heatsafe_scitem"
+          },
+          {
+            "class": "cool_tydt_s01_heatsafe_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_raco_s01_drift_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "MISC_Reliant_Sen": {
+      "name": "Reliant Sen",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 840000,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1850000,
+        "speed": {
+          "max": 1150,
+          "scm": 220,
+          "roll": 138,
+          "pitch": 54,
+          "yaw": 43
+        },
+        "emission": {
+          "ir": 9021,
+          "em_idle": 3082,
+          "em_max": 18215
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 10.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 3500,
+        "engine (right)": 1180,
+        "engine (left)": 1180,
+        "nose": 3000,
+        "wing (right)": 3000,
+        "vertical stabilizer wing (bottom right)": 25,
+        "hardpoint thruster urs": 50,
+        "hardpoint thruster uls": 50,
+        "hardpoint thruster urr": 50,
+        "hardpoint thruster urf": 50,
+        "hardpoint thruster urb": 50,
+        "hardpoint thruster ull": 50,
+        "hardpoint thruster ulf": 50,
+        "hardpoint thruster ulb": 50,
+        "vertical stabilizer wing (top right)": 25,
+        "wing (left)": 3500,
+        "hardpoint thruster llb": 50,
+        "hardpoint thruster llf": 50,
+        "hardpoint thruster lll": 50,
+        "hardpoint thruster lrb": 50,
+        "hardpoint thruster lrf": 50,
+        "hardpoint thruster lrr": 50,
+        "hardpoint thruster lrs": 50,
+        "hardpoint thruster lls": 50,
+        "vertical stabilizer wing (bottom left)": 25,
+        "vertical stabilizer wing (top left)": 25
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          },
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s01_fortitude_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s01_thermax_scitem"
+          },
+          {
+            "class": "cool_just_s01_thermax_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s01_goliath_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "MISC_Reliant_Tana": {
+      "name": "Reliant Tana",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 870000,
+        "crew": 1,
+        "cargo": 1,
+        "stowage": 1420000,
+        "speed": {
+          "max": 1150,
+          "scm": 222,
+          "roll": 155,
+          "pitch": 58,
+          "yaw": 45
+        },
+        "emission": {
+          "ir": 9244,
+          "em_idle": 3822,
+          "em_max": 18826
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 7.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 16,
+          "missle-class": "misl_s02_cs_thcn_strikeforce"
+        },
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 3500,
+        "engine (right)": 1180,
+        "engine (left)": 1180,
+        "nose": 3500,
+        "wing (right)": 2700,
+        "vertical stabilizer wing (bottom right)": 25,
+        "hardpoint thruster urs": 50,
+        "hardpoint thruster uls": 50,
+        "hardpoint thruster urr": 50,
+        "hardpoint thruster urf": 50,
+        "hardpoint thruster urb": 50,
+        "hardpoint thruster ull": 50,
+        "hardpoint thruster ulf": 50,
+        "hardpoint thruster ulb": 50,
+        "vertical stabilizer wing (top right)": 25,
+        "wing (left)": 2700,
+        "hardpoint thruster llb": 50,
+        "hardpoint thruster llf": 50,
+        "hardpoint thruster lll": 50,
+        "hardpoint thruster lrb": 50,
+        "hardpoint thruster lrf": 50,
+        "hardpoint thruster lrr": 50,
+        "hardpoint thruster lrs": 50,
+        "hardpoint thruster lls": 50,
+        "vertical stabilizer wing (bottom left)": 25,
+        "vertical stabilizer wing (top left)": 25
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          },
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s01_beacon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "AEGS_Retaliator": {
+      "name": "Retaliator Bomber",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": 4031700,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 8000000,
+        "speed": {
+          "max": 1100,
+          "scm": 205,
+          "roll": 55,
+          "pitch": 25,
+          "yaw": 23
+        },
+        "emission": {
+          "ir": 15080,
+          "em_idle": 22489,
+          "em_max": 59154
+        },
+        "fuel": {
+          "quantum": 2.6,
+          "hydro": 51
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_retaliator_scitem_turret_lower_rear"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_retaliator_scitem_turret_upper_rear_left"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_retaliator_scitem_turret_upper_rear_right"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_retaliator_scitem_turret_lower"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_retaliator_scitem_turret_upper"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "wing damage (front left)": 100,
+        "wing flp geom (front left)": 100,
+        "wing damage (front right)": 1,
+        "wing flp geom (front right)": 600,
+        "nose": 35000,
+        "hardpoint thruster maneuver retro (frontright)": 50,
+        "hardpoint thruster maneuver retro (frontleft)": 50,
+        "hardpoint thruster maneuver (frontbottomleft)": 5000,
+        "hardpoint thruster maneuver (frontbottomright)": 5000,
+        "hardpoint thruster maneuver (frontright)": 5000,
+        "hardpoint thruster maneuver (frontleft)": 5000,
+        "hardpoint thruster maneuver (fronttopright)": 5000,
+        "hardpoint thruster maneuver (fronttopleft)": 5000,
+        "hardpoint thruster vtol (frontright)": 10000,
+        "hardpoint thruster vtol (frontleft)": 10000,
+        "glass": 100,
+        "body": 50000,
+        "hardpoint thruster maneuver (backleft)": 5000,
+        "hardpoint thruster maneuver (backright)": 5000,
+        "hardpoint thruster maneuver (backtopleft)": 5000,
+        "hardpoint thruster maneuver (backtopright)": 5000,
+        "body (lower right)": 200,
+        "hardpoint thruster maneuver (backbottomright)": 50,
+        "hardpoint mainthruster (right)": 5000,
+        "hardpoint thruster vtol 1 (rearright)": 50,
+        "hardpoint thruster vtol 2 (rearright)": 50,
+        "main wing slider a (right)": 4000,
+        "main wing slider a r (left)": 4000,
+        "large wing piston 003": 4000,
+        "wing rs geom (right)": 50,
+        "wing m geom (right)": 480,
+        "wing m damage (right)": 2800,
+        "wing mlr geom (right)": 480,
+        "wing mlr damage (right)": 240,
+        "wing rl geom (right)": 240,
+        "wing rl damage (right)": 10000,
+        "wing rl fin geom (right)": 50,
+        "body (lower left)": 200,
+        "hardpoint thruster maneuver (backbottomleft)": 50,
+        "hardpoint mainthruster (left)": 5000,
+        "hardpoint thruster vtol 1 (rearleft)": 50,
+        "hardpoint thruster vtol 2 (rearleft)": 50,
+        "wing rs geom (left)": 50,
+        "main wing slider a (left)": 4000,
+        "large wing piston geom l": 4000,
+        "large wing piston 2": 4000,
+        "wing m geom (left)": 480,
+        "wing m damage (left)": 2800,
+        "wing mlr geom (left)": 480,
+        "wing mlr damage (left)": 240,
+        "wing rl geom (left)": 240,
+        "wing rl damage (left)": 10000,
+        "wing rl fin geom (left)": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          },
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          },
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s02_crossfield_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "GRIN_ROC": {
+      "name": "ROC",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": 172000,
+        "crew": 1,
+        "cargo": 1,
+        "stowage": 1080000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 2184,
+          "em_idle": 1305,
+          "em_max": 13195
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "rollcage main": 2250,
+        "hatch (bottom)": 200,
+        "hatch front (top)": 200,
+        "windshield": 200,
+        "frame (rear)": 250,
+        "side panel (right)": 50,
+        "roof": 250,
+        "hardpoint wheel rr": 1500,
+        "hardpoint wheel rl": 1500,
+        "hardpoint wheel fr": 1500,
+        "hardpoint wheel fl": 1500
+      },
+      "components": {
+        "shields": [],
+        "power-plants": [
+          {
+            "class": "powr_just_s00_steadfast_scitem"
+          },
+          {
+            "class": "powr_just_s00_steadfast_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Vantage Rentals, CRU-L1",
+        "Vantage Rentals, ARC-L1",
+        "Vantage Rentals, HUR-L1",
+        "Vantage Rentals, HUR-L2",
+        "Vantage Rentals, MIC-L2"
+      ]
+    },
+    "GRIN_ROC_DS": {
+      "name": "ROC-DS",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": 176500,
+        "crew": 2,
+        "cargo": 3,
+        "stowage": 2150000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 2484,
+          "em_idle": 3743,
+          "em_max": 16120
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "grin roc ds": 1500,
+        "hardpoint wheel mr": 1500,
+        "hardpoint wheel ml": 1500,
+        "hardpoint wheel rr": 1500,
+        "hardpoint wheel rl": 1500,
+        "hardpoint wheel fr assembly": 1,
+        "hardpoint wheel fr": 1500,
+        "hardpoint wheel fl assembly": 1,
+        "hardpoint wheel fl": 1500,
+        "rollcage main": 2250,
+        "hatch (bottom)": 200,
+        "hatch front (top)": 200,
+        "windshield": 200,
+        "frame (rear)": 250,
+        "roof": 250,
+        "light bar": 50
+      },
+      "components": {
+        "shields": [],
+        "power-plants": [
+          {
+            "class": "powr_just_s00_steadfast_scitem"
+          },
+          {
+            "class": "powr_just_s00_steadfast_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "AEGS_Sabre": {
+      "name": "Sabre",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 2183300,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1300000,
+        "speed": {
+          "max": 1235,
+          "scm": 223,
+          "roll": 160,
+          "pitch": 62,
+          "yaw": 48
+        },
+        "emission": {
+          "ir": 7932,
+          "em_idle": 6133,
+          "em_max": 20813
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 13.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 2,
+          "missle-class": "misl_s03_em_fski_thunderbolt"
+        },
+        {
+          "size": 3,
+          "count": 2,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 4000,
+        "wing right (front)": 2000,
+        "wing (right)": 2000,
+        "wing left (front)": 2000,
+        "wing (left)": 2000,
+        "hardpoint weapon missilerack (left)": 1000,
+        "hardpoint weapon missilerack (right)": 1000,
+        "hardpoint engine (right)": 1000,
+        "hardpoint engine (left)": 1000,
+        "wing right (rear)": 2000,
+        "wing left (rear)": 2000,
+        "hardpoint thruster rl (top)": 1000,
+        "hardpoint thruster rr (top)": 1000,
+        "hardpoint thruster fr (top)": 1000,
+        "hardpoint thruster fl (top)": 1000,
+        "hardpoint thruster fr (bottom)": 1000,
+        "hardpoint thruster fl (bottom)": 1000,
+        "hardpoint thruster retro (right)": 1000,
+        "hardpoint thruster retro (left)": 1000,
+        "bay door r a": 500,
+        "bay door r b": 500,
+        "bay door l a": 500,
+        "bay door l b": 500,
+        "hardpoint thruster rl (bottom)": 1000,
+        "hardpoint thruster rr (bottom)": 1000,
+        "nose": 4000,
+        "canopy": 1000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          },
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_tydt_s01_soniclite_scitem"
+          },
+          {
+            "class": "powr_tydt_s01_soniclite_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_raco_s01_drift_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "AEGS_Sabre_Comet": {
+      "name": "Sabre Comet",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 2354100,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1300000,
+        "speed": {
+          "max": 1235,
+          "scm": 223,
+          "roll": 160,
+          "pitch": 62,
+          "yaw": 48
+        },
+        "emission": {
+          "ir": 8302,
+          "em_idle": 5863,
+          "em_max": 20569
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 13.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_scattergun_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_scattergun_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 2,
+          "missle-class": "misl_s03_em_fski_thunderbolt"
+        },
+        {
+          "size": 3,
+          "count": 2,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 4000,
+        "wing right (front)": 2000,
+        "wing (right)": 2000,
+        "wing left (front)": 2000,
+        "wing (left)": 2000,
+        "hardpoint weapon missilerack (left)": 1000,
+        "hardpoint weapon missilerack (right)": 1000,
+        "hardpoint engine (right)": 1000,
+        "hardpoint engine (left)": 1000,
+        "wing right (rear)": 2000,
+        "wing left (rear)": 2000,
+        "hardpoint thruster rl (top)": 1000,
+        "hardpoint thruster rr (top)": 1000,
+        "hardpoint thruster fr (top)": 1000,
+        "hardpoint thruster fl (top)": 1000,
+        "hardpoint thruster fr (bottom)": 1000,
+        "hardpoint thruster fl (bottom)": 1000,
+        "hardpoint thruster retro (right)": 1000,
+        "hardpoint thruster retro (left)": 1000,
+        "bay door r a": 500,
+        "bay door r b": 500,
+        "bay door l a": 500,
+        "bay door l b": 500,
+        "hardpoint thruster rl (bottom)": 1000,
+        "hardpoint thruster rr (bottom)": 1000,
+        "nose": 4000,
+        "canopy": 1000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          },
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_tydt_s01_soniclite_scitem"
+          },
+          {
+            "class": "powr_tydt_s01_soniclite_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_raco_s01_drift_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "AEGS_Sabre_Firebird": {
+      "name": "Sabre Firebird",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1300000,
+        "speed": {
+          "max": 1400,
+          "scm": 240,
+          "roll": 160,
+          "pitch": 49,
+          "yaw": 41
+        },
+        "emission": {
+          "ir": 6293,
+          "em_idle": 5258,
+          "em_max": 21048
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 12
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "gats_ballisticgatling_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 24,
+          "missle-class": "misl_s03_em_fski_thunderbolt"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 2500,
+        "nose": 2500,
+        "canopy": 1000,
+        "tail": 2500,
+        "aegs sabre firebird winglet debris (left)": 500,
+        "aegs sabre firebird winglet debris (right)": 500,
+        "wing (right)": 2000,
+        "wing aileron mesh (right)": 1000,
+        "wing (left)": 2000,
+        "wing aileron mesh (left)": 1000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          },
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_charger_scitem"
+          },
+          {
+            "class": "powr_tydt_s01_soniclite_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_raco_s01_drift_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "AEGS_Sabre_Peregrine": {
+      "name": "Sabre Peregrine",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1300000,
+        "speed": {
+          "max": 1447,
+          "scm": 267,
+          "roll": 187,
+          "pitch": 61,
+          "yaw": 51
+        },
+        "emission": {
+          "ir": 5538,
+          "em_idle": 5013,
+          "em_max": 20733
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 12
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "body": 2400,
+        "wing (right)": 2000,
+        "wing flap (right rear)": 100,
+        "wing aileron mesh a (right)": 100,
+        "wing aileron mesh b (right)": 100,
+        "wing (left)": 2000,
+        "wing flap (left rear)": 100,
+        "wing aileron mesh b (left)": 75,
+        "wing aileron mesh a (left)": 75,
+        "wing flap right (front)": 100,
+        "wing flap left (front)": 100,
+        "tail": 1000,
+        "peregrine wing r top (rear)": 500,
+        "peregrine wing r bottom (rear)": 500,
+        "peregrine wing l top (rear)": 500,
+        "peregrine wing l bottom (rear)": 500,
+        "nose": 2400,
+        "canopy": 1000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          },
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_charger_scitem"
+          },
+          {
+            "class": "powr_tydt_s01_soniclite_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_raco_s01_drift_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "AEGS_Sabre_Raven": {
+      "name": "Sabre Raven",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1300000,
+        "speed": {
+          "max": 1400,
+          "scm": 240,
+          "roll": 160,
+          "pitch": 62,
+          "yaw": 43
+        },
+        "emission": {
+          "ir": 6938,
+          "em_idle": 6877,
+          "em_max": 24597
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 12
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "krig_lasercannon_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "krig_lasercannon_s3"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "body": 2500,
+        "wing (right)": 2000,
+        "wing (left)": 2000,
+        "tail": 2500,
+        "nose": 2500,
+        "canopy": 1000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          },
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_charger_scitem"
+          },
+          {
+            "class": "powr_tydt_s01_soniclite_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_raco_s01_drift_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "XNAA_SanTokYai": {
+      "name": "San'tok.yāi",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 450000,
+        "speed": {
+          "max": 1161,
+          "scm": 227,
+          "roll": 160,
+          "pitch": 58,
+          "yaw": 58
+        },
+        "emission": {
+          "ir": 13647,
+          "em_idle": 8713,
+          "em_max": 27000
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 14.7
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "toag_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "toag_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "toag_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "toag_laserrepeater_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 8,
+          "missle-class": "misl_s02_cs_fski_tempest"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "wings rotator (top right)": 1000,
+        "wings rotator (bottom right)": 1000,
+        "wings rotator (top left)": 1000,
+        "wings rotator (bottom left)": 1000,
+        "wing (front right)": 500,
+        "wing (front bottom right)": 500,
+        "wing (front left)": 500,
+        "wing (front bottom left)": 500,
+        "body": 3675.88,
+        "item tray door right (front)": 250,
+        "item tray door left (front)": 250,
+        "tail right": 600,
+        "tail left": 600,
+        "ejection mesh (top)": 100
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_amrs_s01_dynaflux_scitem"
+          },
+          {
+            "class": "powr_amrs_s01_dynaflux_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s01_beacon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "RSI_Scorpius": {
+      "name": "Scorpius",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 2879700,
+        "crew": 2,
+        "cargo": 0,
+        "stowage": 1890000,
+        "speed": {
+          "max": 1385,
+          "scm": 230,
+          "roll": 145,
+          "pitch": 42,
+          "yaw": 34
+        },
+        "emission": {
+          "ir": 8966,
+          "em_idle": 7754,
+          "em_max": 26272
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 13.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 16,
+          "missle-class": "misl_s02_cs_fski_tempest"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 6500,
+        "canopy (rear)": 80,
+        "canopy (front)": 80,
+        "tail": 6500,
+        "debris turret": 500,
+        "wing mechanism (top left)": 3500,
+        "wing rotator (top left)": 2200,
+        "wing rotator tip left (top)": 1500,
+        "wing retractor (top left)": 300,
+        "wing mechanism (bottom left)": 3500,
+        "wing rotator (bottom left)": 2200,
+        "wing rotator tip left (bottom)": 1500,
+        "wing retractor (bottom left)": 300,
+        "wing mechanism (bottom right)": 3500,
+        "wing rotator (bottom right)": 2200,
+        "wing rotator tip right (bottom)": 1500,
+        "wing retractor (bottom right)": 300,
+        "wing mechanism (top right)": 3500,
+        "wing retractor (top right)": 300,
+        "wing rotator (top right)": 2200,
+        "wing rotator tip right (top)": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          },
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "RSI_Scorpius_Antares": {
+      "name": "Scorpius Antares",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 2,
+        "cargo": 0,
+        "stowage": 1890000,
+        "speed": {
+          "max": 1385,
+          "scm": 230,
+          "roll": 145,
+          "pitch": 42,
+          "yaw": 34
+        },
+        "emission": {
+          "ir": 8281,
+          "em_idle": 10054,
+          "em_max": 34608
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 13.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 16,
+          "missle-class": "misl_s02_cs_fski_tempest"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 6500,
+        "canopy (rear)": 80,
+        "canopy (front)": 80,
+        "tail": 6500,
+        "debris turret": 500,
+        "wing mechanism (top left)": 3500,
+        "wing rotator (top left)": 2200,
+        "wing rotator tip left (top)": 1500,
+        "wing retractor (top left)": 300,
+        "wing mechanism (bottom left)": 3500,
+        "wing rotator (bottom left)": 2200,
+        "wing rotator tip left (bottom)": 1500,
+        "wing retractor (bottom left)": 300,
+        "wing mechanism (bottom right)": 3500,
+        "wing rotator (bottom right)": 2200,
+        "wing rotator tip right (bottom)": 1500,
+        "wing retractor (bottom right)": 300,
+        "wing mechanism (top right)": 3500,
+        "wing retractor (top right)": 300,
+        "wing rotator (top right)": 2200,
+        "wing rotator tip right (top)": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          },
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          },
+          {
+            "class": "powr_aegs_s01_regulus_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "VNCL_Scythe": {
+      "name": "Scythe",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 600000,
+        "speed": {
+          "max": 1150,
+          "scm": 222,
+          "roll": 147,
+          "pitch": 56,
+          "yaw": 52
+        },
+        "emission": {
+          "ir": 9130,
+          "em_idle": 7323,
+          "em_max": 22443
+        },
+        "fuel": {
+          "quantum": 1.3,
+          "hydro": 22
+        }
+      },
+      "weapons": [],
+      "missles": [
+        {
+          "size": 1,
+          "count": 8,
+          "missle-class": "misl_s01_ir_vncl_arrow"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "landing gear cover (rear)": 200,
+        "nose": 4000,
+        "body": 4000,
+        "wing arm (right)": 500,
+        "wing d (right tail)": 1,
+        "wing d featherd hinge (right tail)": 1,
+        "wing d featherd end (right tail)": 1,
+        "wing d featherc hinge (right tail)": 1,
+        "wing d featherc end (right tail)": 1,
+        "wing d featherb hinge (right tail)": 1,
+        "wing d featherb end (right tail)": 1,
+        "wing d feathera hinge (right tail)": 1,
+        "wing d feathera end (right tail)": 1,
+        "wing a (right)": 500,
+        "wing blade lock (right)": 1,
+        "wing a featherd hinge (right)": 1,
+        "wing a featherd end (right)": 1,
+        "wing a featherc hinge (right)": 1,
+        "wing a featherc end (right)": 1,
+        "wing a featherb hinge (right)": 1,
+        "wing a featherb end (right)": 1,
+        "wing a feathera hinge (right)": 1,
+        "wing a feathera end (right)": 1,
+        "wing blade (right)": 1000,
+        "wing c (right tail)": 1,
+        "wing b (right tail)": 1,
+        "wing a (right tail)": 1,
+        "wing gun (right)": 500,
+        "wing arm (left)": 500,
+        "wing (left)": 480,
+        "hardpoint thruster fixed (top front left)": 50,
+        "hardpoint thruster joint (top back right)": 50,
+        "hardpoint thruster joint (top back left)": 50,
+        "hardpoint thruster side fixed (front right)": 50,
+        "hardpoint thruster side fixed (front left)": 50,
+        "hardpoint thruster side fixed (back right)": 50,
+        "hardpoint thruster side fixed (back left)": 50,
+        "hardpoint thruster retro (right)": 50,
+        "hardpoint thruster retro (left)": 50,
+        "hardpoint thruster joint (bottom front right)": 50,
+        "hardpoint thruster joint (bottom front left)": 50,
+        "hardpoint thruster joint (bottom back right)": 50,
+        "hardpoint thruster joint (bottom back left)": 50,
+        "hardpoint thruster fixed (top front right)": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          },
+          {
+            "class": "shld_godi_s01_allstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s01_fierellcascade_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_bracer_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s01_beacon_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ANVL_Spartan": {
+      "name": "Spartan",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": 255500,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1060000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 1790,
+          "em_idle": 1708,
+          "em_max": 14588
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "anvl spartan": 4200,
+        "hardpoint wheel 04 (right)": 1700,
+        "hardpoint wheel 03 (right)": 1700,
+        "hardpoint wheel 02 (right)": 1700,
+        "hardpoint wheel 01 (right)": 1700,
+        "hardpoint wheel 02 (left)": 1700,
+        "hardpoint wheel 04 (left)": 1700,
+        "hardpoint wheel 03 (left)": 1700,
+        "hardpoint wheel 01 (left)": 1700,
+        "body": 10000,
+        "nose": 10000,
+        "wheel01dmggroup (frontleft)": 1
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s00_castra_scitem"
+          },
+          {
+            "class": "shld_basl_s00_castra_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s00_defiant_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_cryostarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ARGO_SRV": {
+      "name": "SRV",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 12,
+        "stowage": 930000,
+        "speed": {
+          "max": 1100,
+          "scm": 200,
+          "roll": 60,
+          "pitch": 30,
+          "yaw": 30
+        },
+        "emission": {
+          "ir": 9734,
+          "em_idle": 3420,
+          "em_max": 30947
+        },
+        "fuel": {
+          "quantum": 3.1,
+          "hydro": 28.5
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        }
+      ],
+      "health": {
+        "body": 10000,
+        "rear": 8500,
+        "nacelle (left)": 2500,
+        "vtol cylinder mesh (rear left)": 1000,
+        "vtol mesh (rear left upper)": 500,
+        "vtol mesh (rear left lower)": 500,
+        "vtol cylinder mesh (mid left)": 1000,
+        "vtol mesh (mid left lower)": 500,
+        "vtol mesh (mid left upper)": 500,
+        "debris maintractorbeamarm": 1000,
+        "nacelle (right)": 2500,
+        "vtol cylinder mesh (rear right)": 1000,
+        "vtol mesh (rear right upper)": 500,
+        "vtol mesh (rear right lower)": 500,
+        "vtol cylinder mesh (mid right)": 1000,
+        "vtol mesh (mid right lower)": 500,
+        "vtol mesh (mid right upper)": 500,
+        "vtol mesh (front right upper)": 500,
+        "vtol mesh (front right lower)": 500,
+        "vtol mesh (front left upper)": 500,
+        "vtol mesh (front left lower)": 500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_behr_s02_5ma_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s02_diligence_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s02_coolcore_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s02_huracan_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "MISC_Starfarer": {
+      "name": "Starfarer",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": 6651500,
+        "crew": 1,
+        "cargo": 291,
+        "stowage": 9140000,
+        "speed": {
+          "max": 845,
+          "scm": 106,
+          "roll": 45,
+          "pitch": 23,
+          "yaw": 23
+        },
+        "emission": {
+          "ir": 16416,
+          "em_idle": 25376,
+          "em_max": 62348
+        },
+        "fuel": {
+          "quantum": 8.6,
+          "hydro": 1012.2
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "misc_starfarer_scitem_turret_large"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "misc_starfarer_scitem_turret_small"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "misc_starfarer_scitem_turret_small_right"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "body": 31500,
+        "hardpoint thruster vtol fr": 100,
+        "hardpoint thruster vtol fl": 100,
+        "wing (back left)": 3600,
+        "hardpoint thruster vtol rl": 100,
+        "leg (left)": 2200,
+        "hardpoint thruster rl (top)": 50,
+        "hardpoint thruster side rl": 50,
+        "hardpoint thruster rl (bottom)": 50,
+        "hardpoint engine (left)": 50,
+        "wing (back right)": 3600,
+        "hardpoint thruster vtol rr": 100,
+        "leg (right)": 2200,
+        "spoiler mid": 1200,
+        "hardpoint thruster side rr": 50,
+        "hardpoint thruster rr (bottom)": 50,
+        "hardpoint engine (right)": 50,
+        "hardpoint thruster rr (top)": 50,
+        "hardpoint thruster fr (bottom)": 50,
+        "hardpoint thruster fl (bottom)": 50,
+        "hardpoint thruster fr (top)": 50,
+        "hardpoint thruster fl (top)": 50,
+        "nose": 31500,
+        "hardpoint thruster side fr": 50,
+        "hardpoint thruster side fl": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          },
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          },
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s03_ginzel_scitem"
+          },
+          {
+            "class": "powr_amrs_s03_superdrive_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s03_thermalcore_scitem"
+          },
+          {
+            "class": "cool_just_s03_thermalcore_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s03_kama_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "MISC_Starfarer_Gemini": {
+      "name": "Starfarer Gemini",
+      "stats": {
+        "ship-size": "large",
+        "purchase-price": 6191500,
+        "crew": 2,
+        "cargo": 291,
+        "stowage": 9140000,
+        "speed": {
+          "max": 845,
+          "scm": 106,
+          "roll": 45,
+          "pitch": 23,
+          "yaw": 23
+        },
+        "emission": {
+          "ir": 13450,
+          "em_idle": 22561,
+          "em_max": 56833
+        },
+        "fuel": {
+          "quantum": 8.6,
+          "hydro": 1012.2
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "misc_starfarer_gemini_scitem_turret_large"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "misc_starfarer_gemini_scitem_turret_small"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "misc_starfarer_gemini_scitem_turret_small_right"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 9,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 31500,
+        "hardpoint thruster vtol fr": 100,
+        "hardpoint thruster vtol fl": 100,
+        "wing (back left)": 3600,
+        "hardpoint thruster vtol rl": 100,
+        "leg (left)": 2200,
+        "hardpoint thruster rl (top)": 50,
+        "hardpoint thruster side rl": 50,
+        "hardpoint thruster rl (bottom)": 50,
+        "hardpoint engine (left)": 50,
+        "wing (back right)": 3600,
+        "hardpoint thruster vtol rr": 100,
+        "leg (right)": 2200,
+        "spoiler mid": 1200,
+        "hardpoint thruster side rr": 50,
+        "hardpoint thruster rr (bottom)": 50,
+        "hardpoint engine (right)": 50,
+        "hardpoint thruster rr (top)": 50,
+        "hardpoint thruster fr (bottom)": 50,
+        "hardpoint thruster fl (bottom)": 50,
+        "hardpoint thruster fr (top)": 50,
+        "hardpoint thruster fl (top)": 50,
+        "nose": 33059.25,
+        "hardpoint thruster side fr": 50,
+        "hardpoint thruster side fl": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          },
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          },
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_amrs_s03_superdrive_scitem"
+          },
+          {
+            "class": "powr_amrs_s03_superdrive_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s03_mercury_scitem"
+          },
+          {
+            "class": "cool_aegs_s03_mercury_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s03_pontes_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "MISC_Starlancer_Max": {
+      "name": "Starlancer MAX",
+      "stats": {
+        "ship-size": "undefined",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 224,
+        "stowage": 8000000,
+        "speed": {
+          "max": 990,
+          "scm": 160,
+          "roll": 65,
+          "pitch": 31,
+          "yaw": 31
+        },
+        "emission": {
+          "ir": 16359,
+          "em_idle": 8362,
+          "em_max": 33822
+        },
+        "fuel": {
+          "quantum": 3.6,
+          "hydro": 50
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 16,
+          "missle-class": "misl_s03_em_fski_thunderbolt"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 35000,
+        "nose": 20000,
+        "spoiler right (top)": 200,
+        "spoiler left (top)": 200,
+        "spoiler connection (right)": 200,
+        "spoiler right (rear)": 200,
+        "spoiler connection (left)": 200,
+        "spoiler left (rear)": 200,
+        "nacelle (right)": 7000,
+        "wing plate (right)": 1000,
+        "wing (right)": 2000,
+        "wing (right rear)": 1000,
+        "wing aileron (right)": 1000,
+        "nacelle (right rear)": 2000,
+        "nacelle (left)": 7000,
+        "wing plate (left)": 1000,
+        "wing (left)": 2000,
+        "wing (left rear)": 1000,
+        "wing aileron (left)": 1000,
+        "nacelle (left rear)": 2000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_acom_s02_luxcore_scitem"
+          },
+          {
+            "class": "powr_acom_s02_luxcore_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_acom_s02_absolutezero_scitem"
+          },
+          {
+            "class": "cool_acom_s02_absolutezero_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_acas_s02_sparkfire_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "MISC_Starlancer_TAC": {
+      "name": "Starlancer TAC",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 96,
+        "stowage": 0,
+        "speed": {
+          "max": 960,
+          "scm": 150,
+          "roll": 60,
+          "pitch": 27,
+          "yaw": 27
+        },
+        "emission": {
+          "ir": 18059,
+          "em_idle": 16082,
+          "em_max": 43354
+        },
+        "fuel": {
+          "quantum": 3.35,
+          "hydro": 48
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "misc_starlancer_tac_side_turret_left"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "misc_starlancer_tac_side_turret"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "behr_lasercannon_s4"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 16,
+          "missle-class": "misl_s03_em_fski_thunderbolt"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 38000,
+        "nacelle (right)": 8000,
+        "wing plate (right)": 6000,
+        "wing (right)": 3000,
+        "wing (right rear)": 1500,
+        "wing aileron (right)": 500,
+        "nacelle (right rear)": 2000,
+        "geo nacelle fin 012": 500,
+        "geo nacelle fin 011": 500,
+        "geo nacelle fin 010": 500,
+        "geo nacelle fin 009": 500,
+        "geo nacelle fin 008": 500,
+        "geo nacelle fin 007": 500,
+        "nacelle air brake (right)": 600,
+        "nose": 25000,
+        "spoiler right (top)": 1200,
+        "spoiler left (top)": 1200,
+        "spoiler connection (right)": 500,
+        "spoiler right (rear)": 500,
+        "spoiler connection (left)": 500,
+        "spoiler left (rear)": 500,
+        "nacelle (left)": 8000,
+        "wing plate (left)": 6000,
+        "wing (left)": 3000,
+        "wing (left rear)": 1500,
+        "wing aileron (left)": 500,
+        "nacelle air brake (left)": 600,
+        "nacelle (left rear)": 2000,
+        "geo nacelle fin 06": 500,
+        "geo nacelle fin 01": 500,
+        "geo nacelle fin 02": 500,
+        "geo nacelle fin 03": 500,
+        "geo nacelle fin 05": 500,
+        "geo nacelle fin 04": 500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          },
+          {
+            "class": "shld_basl_s03_stronghold_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s03_centurion_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s03_blizzard_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_acas_s02_sparkfire_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "TMBL_Storm": {
+      "name": "Storm",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1440000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 1540,
+          "em_idle": 1806,
+          "em_max": 14030
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "hrst_storm_laserrepeater_s3"
+        }
+      ],
+      "missles": [],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Joker Defcon - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        },
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Joker Defcon - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "tmbl storm": 35000,
+        "body": 27000,
+        "blast plate body (left)": 200,
+        "radar debody right (tail)": 100,
+        "radar debody left (tail)": 100,
+        "blast plate body (right)": 200,
+        "hardpoint wheel hidden2 (rear right)": 700,
+        "hardpoint wheel hidden2 (rear left)": 700,
+        "hardpoint wheel bumper right (front)": 700,
+        "hardpoint wheel bumper left (front)": 700,
+        "hardpoint wheel center1 (front left)": 700,
+        "hardpoint wheel center2 (front right)": 700,
+        "hardpoint wheel center1 (front right)": 700,
+        "hardpoint wheel center2 (front left)": 700,
+        "hardpoint wheel gap2 (front right)": 700,
+        "hardpoint wheel gap2 (front left)": 700,
+        "hardpoint wheel gap1 (front right)": 700,
+        "hardpoint wheel gap1 (front left)": 700,
+        "hardpoint wheel 02 (front left)": 700,
+        "hardpoint wheel 04 (front left)": 700,
+        "hardpoint wheel 01 (front left)": 700,
+        "hardpoint wheel 06 (rear left)": 700,
+        "hardpoint wheel 08 (rear left)": 700,
+        "hardpoint wheel 11 (rear left)": 700,
+        "hardpoint wheel 00 (front left)": 700,
+        "hardpoint wheel 12 (rear left)": 700,
+        "hardpoint wheel 02 (front right)": 700,
+        "hardpoint wheel 04 (front right)": 700,
+        "hardpoint wheel hidden (rear left)": 700,
+        "hardpoint wheel 06 (rear right)": 700,
+        "hardpoint wheel 08 (rear right)": 700,
+        "hardpoint wheel 01 (front right)": 700,
+        "hardpoint wheel 11 (rear right)": 700,
+        "hardpoint wheel 12 (rear right)": 700,
+        "hardpoint wheel 06 (front left)": 700,
+        "hardpoint wheel 06 (front right)": 700,
+        "hardpoint wheel hidden (front left)": 700,
+        "hardpoint wheel hidden (front right)": 700,
+        "hardpoint wheel 013 (rear left)": 700,
+        "hardpoint wheel 013 (rear right)": 700,
+        "hardpoint wheel 014 (rear left)": 700,
+        "hardpoint wheel 014 (rear right)": 700,
+        "hardpoint wheel hidden (rear right)": 700,
+        "hardpoint wheel 00 (front right)": 700,
+        "component door (rear right)": 500,
+        "component door (rear left)": 500,
+        "tread cover fr": 5000,
+        "radar de (tail front right)": 100,
+        "component door fr (front)": 500,
+        "component door fr (back)": 500,
+        "blast plate (front right)": 200,
+        "tread cover rr": 5000,
+        "blast shield b (rear right)": 200,
+        "blast shield a (back right)": 200,
+        "component door rr (back)": 500,
+        "component door rr (front)": 500,
+        "tread cover rl": 5000,
+        "blast plate b (rear left)": 200,
+        "blast plate a (rear left)": 200,
+        "component door rl (back)": 500,
+        "component door rl (front)": 500,
+        "tread cover fl": 5000,
+        "radar de (tail front left)": 100,
+        "blast plate (front left)": 200,
+        "component door fl (front)": 500,
+        "component door fl (back)": 500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "TMBL_Storm_AA": {
+      "name": "Storm AA",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1440000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 1240,
+          "em_idle": 1706,
+          "em_max": 13930
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 5
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Joker Defcon - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        },
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Joker Defcon - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "tmbl storm": 35000,
+        "body": 27000,
+        "blast plate body (left)": 200,
+        "radar debody right (tail)": 100,
+        "radar debody left (tail)": 100,
+        "blast plate body (right)": 200,
+        "hardpoint wheel hidden2 (rear right)": 700,
+        "hardpoint wheel hidden2 (rear left)": 700,
+        "hardpoint wheel bumper right (front)": 700,
+        "hardpoint wheel bumper left (front)": 700,
+        "hardpoint wheel center1 (front left)": 700,
+        "hardpoint wheel center2 (front right)": 700,
+        "hardpoint wheel center1 (front right)": 700,
+        "hardpoint wheel center2 (front left)": 700,
+        "hardpoint wheel gap2 (front right)": 700,
+        "hardpoint wheel gap2 (front left)": 700,
+        "hardpoint wheel gap1 (front right)": 700,
+        "hardpoint wheel gap1 (front left)": 700,
+        "hardpoint wheel 02 (front left)": 700,
+        "hardpoint wheel 04 (front left)": 700,
+        "hardpoint wheel 01 (front left)": 700,
+        "hardpoint wheel 06 (rear left)": 700,
+        "hardpoint wheel 08 (rear left)": 700,
+        "hardpoint wheel 11 (rear left)": 700,
+        "hardpoint wheel 00 (front left)": 700,
+        "hardpoint wheel 12 (rear left)": 700,
+        "hardpoint wheel 02 (front right)": 700,
+        "hardpoint wheel 04 (front right)": 700,
+        "hardpoint wheel hidden (rear left)": 700,
+        "hardpoint wheel 06 (rear right)": 700,
+        "hardpoint wheel 08 (rear right)": 700,
+        "hardpoint wheel 01 (front right)": 700,
+        "hardpoint wheel 11 (rear right)": 700,
+        "hardpoint wheel 12 (rear right)": 700,
+        "hardpoint wheel 06 (front left)": 700,
+        "hardpoint wheel 06 (front right)": 700,
+        "hardpoint wheel hidden (front left)": 700,
+        "hardpoint wheel hidden (front right)": 700,
+        "hardpoint wheel 013 (rear left)": 700,
+        "hardpoint wheel 013 (rear right)": 700,
+        "hardpoint wheel 014 (rear left)": 700,
+        "hardpoint wheel 014 (rear right)": 700,
+        "hardpoint wheel hidden (rear right)": 700,
+        "hardpoint wheel 00 (front right)": 700,
+        "component door (rear right)": 500,
+        "component door (rear left)": 500,
+        "tread cover fr": 5000,
+        "radar de (tail front right)": 100,
+        "component door fr (front)": 500,
+        "component door fr (back)": 500,
+        "blast plate (front right)": 200,
+        "tread cover rr": 5000,
+        "blast shield b (rear right)": 200,
+        "blast shield a (back right)": 200,
+        "component door rr (back)": 500,
+        "component door rr (front)": 500,
+        "tread cover rl": 5000,
+        "blast plate b (rear left)": 200,
+        "blast plate a (rear left)": 200,
+        "component door rl (back)": 500,
+        "component door rl (front)": 500,
+        "tread cover fl": 5000,
+        "radar de (tail front left)": 100,
+        "blast plate (front left)": 200,
+        "component door fl (front)": 500,
+        "component door fl (back)": 500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "GRIN_STV": {
+      "name": "STV",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": 12000,
+        "crew": 2,
+        "cargo": 0,
+        "stowage": 125000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 1135,
+          "em_idle": 1305,
+          "em_max": 13087
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "body": 2500,
+        "fender fl": 250,
+        "fender rr": 250,
+        "fender rl": 250,
+        "fender fr": 250,
+        "bonnet arm": 250,
+        "mesh bonnet plate": 500
+      },
+      "components": {
+        "shields": [],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_cryostarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "GAMA_Syulen": {
+      "name": "Syulen",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 6,
+        "stowage": 1310000,
+        "speed": {
+          "max": 1175,
+          "scm": 225,
+          "roll": 135,
+          "pitch": 42,
+          "yaw": 42
+        },
+        "emission": {
+          "ir": 12786,
+          "em_idle": 3026,
+          "em_max": 16596
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 40
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 12,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "body": 2000,
+        "wing large (right)": 1500,
+        "wing large fin right (right)": 220,
+        "wing large fin left (right)": 220,
+        "wing large (top)": 1500,
+        "wing large fin right (top)": 220,
+        "wing large fin left (top)": 220,
+        "wing large (left)": 1500,
+        "wing large fin right (left)": 220,
+        "wing large fin left (left)": 220,
+        "wing small (right)": 700,
+        "wing small fin right (right)": 220,
+        "wing small fin left (right)": 220,
+        "wing small (left)": 700,
+        "wing small fin right (left)": 220,
+        "wing small fin left (left)": 220,
+        "wing small (bottom)": 700,
+        "wing small fin right (bottom)": 220,
+        "wing small fin left (bottom)": 220,
+        "mesh (front)": 500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s01_hex_scitem"
+          },
+          {
+            "class": "shld_seco_s01_hex_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_sasu_s01_lightblossom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_lplt_s01_blastchill_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_acas_s01_foxfire_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ESPR_Talon": {
+      "name": "Talon",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 1854500,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1300000,
+        "speed": {
+          "max": 1190,
+          "scm": 225,
+          "roll": 195,
+          "pitch": 68,
+          "yaw": 54
+        },
+        "emission": {
+          "ir": 10426,
+          "em_idle": 7112,
+          "em_max": 21452
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 8
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "espr_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "espr_lasercannon_s4"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_cs_fski_tempest"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 2000,
+        "tail right": 1650,
+        "wing (right)": 1850,
+        "wing (left)": 1850,
+        "tail left": 1650,
+        "leg (left)": 1900,
+        "wing small segment 01 (left)": 1300,
+        "wings small feathers 07 (left)": 150,
+        "wings small feathers 06 (left)": 150,
+        "wings small feathers 05 (left)": 150,
+        "wings small feathers 04 (left)": 150,
+        "wings small feathers 03 (left)": 150,
+        "wings small feathers 02 (left)": 150,
+        "wings small feathers 01 (left)": 150,
+        "leg (lower left)": 1500,
+        "leg feathers 01 (left)": 150,
+        "leg feathers 02 (left)": 150,
+        "leg feathers 03 (left)": 150,
+        "leg feathers 04 (left)": 150,
+        "leg feathers 05 (left)": 150,
+        "shieldgen door outer (left)": 150,
+        "shieldgen door inner (left)": 150,
+        "shieldgen door inner (right)": 150,
+        "shieldgen door outer (right)": 150,
+        "coolers door (left)": 150,
+        "coolers door (front)": 150,
+        "coolers door (right)": 150,
+        "coolers door (rear)": 150,
+        "coolers door mid": 150,
+        "radar scanner door (left)": 150,
+        "radar scanner door (front)": 150,
+        "radar scanner door mid": 150,
+        "radar scanner door (rear)": 150,
+        "radar scanner door (right)": 150,
+        "comp jumpdrive door (left)": 150,
+        "comp jumpdrive door (right)": 150,
+        "comp jumpdrive door (rear)": 150,
+        "comp jumpdrive door mid": 150,
+        "comp jumpdrive door (front)": 150,
+        "leg (right)": 1900,
+        "wing small segment 01 (right)": 1300,
+        "wings small feathers 07 (right)": 150,
+        "wings small feathers 06 (right)": 150,
+        "wings small feathers 05 (right)": 150,
+        "wings small feathers 04 (right)": 150,
+        "wings small feathers 03 (right)": 150,
+        "wings small feathers 02 (right)": 150,
+        "wings small feathers 01 (right)": 150,
+        "leg (lower right)": 1500,
+        "leg feathers 05 (right)": 150,
+        "leg feathers 04 (right)": 150,
+        "leg feathers 03 (right)": 150,
+        "leg feathers 02 (right)": 150,
+        "leg feathers 01 (right)": 150,
+        "eject joint": 80
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          },
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_tydt_s01_slipstream_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_tydt_s01_vaporblock_scitem"
+          },
+          {
+            "class": "cool_tydt_s01_vaporblock_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_raco_s01_drift_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ESPR_Talon_Shrike": {
+      "name": "Talon Shrike",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 2259200,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1300000,
+        "speed": {
+          "max": 1190,
+          "scm": 225,
+          "roll": 195,
+          "pitch": 68,
+          "yaw": 54
+        },
+        "emission": {
+          "ir": 10376,
+          "em_idle": 6922,
+          "em_max": 21262
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 8
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "espr_lasercannon_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "espr_lasercannon_s2"
+        }
+      ],
+      "missles": [
+        {
+          "size": 3,
+          "count": 24,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 2000,
+        "tail right": 1650,
+        "wing (right)": 1850,
+        "wing (left)": 1850,
+        "tail left": 1650,
+        "leg (left)": 1900,
+        "wing small segment 01 (left)": 1300,
+        "wings small feathers 07 (left)": 150,
+        "wings small feathers 06 (left)": 150,
+        "wings small feathers 05 (left)": 150,
+        "wings small feathers 04 (left)": 150,
+        "wings small feathers 03 (left)": 150,
+        "wings small feathers 02 (left)": 150,
+        "wings small feathers 01 (left)": 150,
+        "leg (lower left)": 1500,
+        "leg feathers 01 (left)": 150,
+        "leg feathers 02 (left)": 150,
+        "leg feathers 03 (left)": 150,
+        "leg feathers 04 (left)": 150,
+        "leg feathers 05 (left)": 150,
+        "shieldgen door outer (left)": 150,
+        "shieldgen door inner (left)": 150,
+        "shieldgen door inner (right)": 150,
+        "shieldgen door outer (right)": 150,
+        "coolers door (left)": 150,
+        "coolers door (front)": 150,
+        "coolers door (right)": 150,
+        "coolers door (rear)": 150,
+        "coolers door mid": 150,
+        "radar scanner door (left)": 150,
+        "radar scanner door (front)": 150,
+        "radar scanner door mid": 150,
+        "radar scanner door (rear)": 150,
+        "radar scanner door (right)": 150,
+        "comp jumpdrive door (left)": 150,
+        "comp jumpdrive door (right)": 150,
+        "comp jumpdrive door (rear)": 150,
+        "comp jumpdrive door mid": 150,
+        "comp jumpdrive door (front)": 150,
+        "leg (right)": 1900,
+        "wing small segment 01 (right)": 1300,
+        "wings small feathers 07 (right)": 150,
+        "wings small feathers 06 (right)": 150,
+        "wings small feathers 05 (right)": 150,
+        "wings small feathers 04 (right)": 150,
+        "wings small feathers 03 (right)": 150,
+        "wings small feathers 02 (right)": 150,
+        "wings small feathers 01 (right)": 150,
+        "leg (lower right)": 1500,
+        "leg feathers 05 (right)": 150,
+        "leg feathers 04 (right)": 150,
+        "leg feathers 03 (right)": 150,
+        "leg feathers 02 (right)": 150,
+        "leg feathers 01 (right)": 150,
+        "eject joint": 80
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          },
+          {
+            "class": "shld_asas_s01_shimmer_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_tydt_s01_slipstream_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_tydt_s01_vaporblock_scitem"
+          },
+          {
+            "class": "cool_tydt_s01_vaporblock_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_raco_s01_drift_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ANVL_Terrapin": {
+      "name": "Terrapin",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 2568100,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1850000,
+        "speed": {
+          "max": 1150,
+          "scm": 200,
+          "roll": 120,
+          "pitch": 35,
+          "yaw": 35
+        },
+        "emission": {
+          "ir": 5835,
+          "em_idle": 7583,
+          "em_max": 25175
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 104.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 20000,
+        "leg (front right)": 10000,
+        "terrapin thruster main (front right)": 10000,
+        "main thruster base right (front)": 1000,
+        "tail": 20000,
+        "plate (tail top)": 200,
+        "flap (top left)": 1000,
+        "flap (top right)": 1000,
+        "leg (rear left)": 10000,
+        "terrapin thruster main (rear left)": 10000,
+        "main thruster base left (rear)": 1000,
+        "main thruster wing bot (rear left)": 3000,
+        "main thruster wing top (rear left)": 3000,
+        "leg (rear right)": 10000,
+        "terrapin thruster main (rear right)": 10000,
+        "main thruster base right (rear)": 1000,
+        "main thruster wing bot (rear right)": 3000,
+        "main thruster wing top (rear right)": 3000,
+        "fuelport inflight housing": 1,
+        "nose": 15000,
+        "body (bottom)": 15000,
+        "leg (front left)": 10000,
+        "terrapin thruster main (front left)": 10000,
+        "main thruster base left (front)": 1000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_behr_s02_5ma_scitem"
+          },
+          {
+            "class": "shld_behr_s02_5ma_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_sasu_s02_daybreak_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "ANVL_Terrapin_Medic": {
+      "name": "Terrapin Medic",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1850000,
+        "speed": {
+          "max": 1150,
+          "scm": 200,
+          "roll": 120,
+          "pitch": 35,
+          "yaw": 35
+        },
+        "emission": {
+          "ir": 6040,
+          "em_idle": 7583,
+          "em_max": 25175
+        },
+        "fuel": {
+          "quantum": 4,
+          "hydro": 104.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s2"
+        }
+      ],
+      "missles": [],
+      "defensive": [
+        {
+          "type": "decoy",
+          "count": 48,
+          "name": "Aegis Gladius - Decoy Launcher"
+        },
+        {
+          "type": "noise",
+          "count": 5,
+          "name": "Joker Defcon - Noise Launcher"
+        }
+      ],
+      "health": {
+        "body": 20000,
+        "leg (front right)": 10000,
+        "terrapin thruster main (front right)": 10000,
+        "main thruster base right (front)": 1000,
+        "tail": 20000,
+        "plate (tail top)": 200,
+        "flap (top left)": 1000,
+        "flap (top right)": 1000,
+        "leg (rear left)": 10000,
+        "terrapin thruster main (rear left)": 10000,
+        "main thruster base left (rear)": 1000,
+        "main thruster wing bot (rear left)": 3000,
+        "main thruster wing top (rear left)": 3000,
+        "leg (rear right)": 10000,
+        "terrapin thruster main (rear right)": 10000,
+        "main thruster base right (rear)": 1000,
+        "main thruster wing bot (rear right)": 3000,
+        "main thruster wing top (rear right)": 3000,
+        "fuelport inflight housing": 1,
+        "nose": 15000,
+        "body (bottom)": 15000,
+        "leg (front left)": 10000,
+        "terrapin thruster main (front left)": 10000,
+        "main thruster base left (front)": 1000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_behr_s02_5ma_scitem"
+          },
+          {
+            "class": "shld_behr_s02_5ma_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_sasu_s02_daybreak_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          },
+          {
+            "class": "cool_aegs_s01_polar_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s01_eos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "RSI_Ursa_Rover": {
+      "name": "Ursa",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": 66300,
+        "crew": 2,
+        "cargo": 0,
+        "stowage": 2460000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 1287,
+          "em_idle": 1342,
+          "em_max": 13569
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "rsi ursa rover": 2000,
+        "body": 13000,
+        "wheel6 mudguard": 150,
+        "wheel6": 1500,
+        "wheel5 mudguard": 150,
+        "wheel5": 1500,
+        "wheel4 mudguard": 150,
+        "wheel4": 1500,
+        "wheel3 mudguard": 150,
+        "wheel3": 1500,
+        "wheel2 mudguard": 150,
+        "wheel2 center": 150,
+        "wheel2": 1500,
+        "wheel1 mudguard": 150,
+        "wheel1 center": 150,
+        "wheel1": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "RSI_Ursa_Rover_Emerald": {
+      "name": "Ursa Fortuna",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": null,
+        "crew": 2,
+        "cargo": 0,
+        "stowage": 2460000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 1287,
+          "em_idle": 1342,
+          "em_max": 13569
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "rsi ursa rover": 2000,
+        "body": 13000,
+        "wheel6 mudguard": 150,
+        "wheel6": 1500,
+        "wheel5 mudguard": 150,
+        "wheel5": 1500,
+        "wheel4 mudguard": 150,
+        "wheel4": 1500,
+        "wheel3 mudguard": 150,
+        "wheel3": 1500,
+        "wheel2 mudguard": 150,
+        "wheel2 center": 150,
+        "wheel2": 1500,
+        "wheel1 mudguard": 150,
+        "wheel1 center": 150,
+        "wheel1": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "RSI_Ursa_Medivac": {
+      "name": "Ursa Medivac",
+      "stats": {
+        "ship-size": "vehicle",
+        "purchase-price": null,
+        "crew": 2,
+        "cargo": 0,
+        "stowage": 2460000,
+        "speed": {
+          "max": 0,
+          "scm": 0,
+          "roll": 0,
+          "pitch": 0,
+          "yaw": 0
+        },
+        "emission": {
+          "ir": 1287,
+          "em_idle": 1342,
+          "em_max": 13569
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "rsi ursa rover": 2000,
+        "body": 14500,
+        "wheel6 mudguard": 150,
+        "wheel6": 1500,
+        "wheel5 mudguard": 150,
+        "wheel5": 1500,
+        "wheel4 mudguard": 150,
+        "wheel4": 1500,
+        "wheel3 mudguard": 150,
+        "wheel3": 1500,
+        "wheel2 mudguard": 150,
+        "wheel2 center": 150,
+        "wheel2": 1500,
+        "wheel1 mudguard": 150,
+        "wheel1 center": 150,
+        "wheel1": 1500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_jspn_s00_froststarsl_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ANVL_Valkyrie": {
+      "name": "Valkyrie",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": 4454400,
+        "crew": 1,
+        "cargo": 90,
+        "stowage": 4630000,
+        "speed": {
+          "max": 1110,
+          "scm": 207,
+          "roll": 98,
+          "pitch": 34,
+          "yaw": 29
+        },
+        "emission": {
+          "ir": 17393,
+          "em_idle": 21729,
+          "em_max": 57336
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 378
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "anvl_valkyrie_turret_bubble"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s3"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "anvl_valkyrie_turret_top"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "nose": 25000,
+        "nose shell": 50,
+        "lights nose": 1,
+        "engine fr": 150,
+        "engine fr split": 6500,
+        "engine fl": 150,
+        "engine fl split": 6500,
+        "tail": 25000,
+        "shell (tail)": 1,
+        "engine rl": 150,
+        "engine rl split": 6500,
+        "engine rr": 150,
+        "engine rr split": 6500,
+        "lights engine rr split": 1,
+        "wing rl": 2000,
+        "wing rr": 2000,
+        "wing (right)": 4500,
+        "decal wing (right)": 200,
+        "wing (left)": 4500,
+        "decal wing (left)": 200
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          },
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          },
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_tars_s02_odyssey_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "Astro Armada, Area 18"
+      ]
+    },
+    "AEGS_Vanguard_Harbinger": {
+      "name": "Vanguard Harbinger",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": 2050500,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1850000,
+        "speed": {
+          "max": 1085,
+          "scm": 212,
+          "roll": 120,
+          "pitch": 41,
+          "yaw": 35
+        },
+        "emission": {
+          "ir": 11249,
+          "em_idle": 15074,
+          "em_max": 46592
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 39
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "rpod_s3_fski_9x_s3"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "rpod_s3_fski_9x_s3"
+        },
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_vanguard_harbinger_scitem_turret"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "espr_ballisticcannon_s5"
+        }
+      ],
+      "missles": [
+        {
+          "size": 5,
+          "count": 3,
+          "missle-class": "misl_s05_cs_taln_stalker"
+        },
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        },
+        {
+          "size": 3,
+          "count": 4,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        },
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_em_taln_dominator"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "wing geo (left)": 800,
+        "wing geo (right)": 800,
+        "wing flaps geo (left)": 600,
+        "wing flaps geo (right)": 600,
+        "body": 10000,
+        "wing (back left)": 1800,
+        "wing (back right)": 1800,
+        "engine l": 7500,
+        "fin left lower (tail)": 250,
+        "fin left upper (tail)": 250,
+        "engine r": 7500,
+        "fin right lower (tail)": 250,
+        "fin right upper (tail)": 250,
+        "arm (left)": 200,
+        "arm (right)": 200,
+        "nose": 10000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_secureshield_scitem"
+          },
+          {
+            "class": "shld_godi_s02_secureshield_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_amrs_s02_turbodrive_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s02_permafrost_scitem"
+          },
+          {
+            "class": "cool_aegs_s02_permafrost_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s02_yeager_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "AEGS_Vanguard_Hoplite": {
+      "name": "Vanguard Hoplite",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": 3104200,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1850000,
+        "speed": {
+          "max": 1115,
+          "scm": 209,
+          "roll": 105,
+          "pitch": 35,
+          "yaw": 30
+        },
+        "emission": {
+          "ir": 11434,
+          "em_idle": 12879,
+          "em_max": 41093
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 39
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_vanguard_scitem_turret"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "espr_ballisticcannon_s5"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        },
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_em_taln_dominator"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "wing geo (left)": 2000,
+        "wing geo (right)": 2000,
+        "wing flaps geo (left)": 1200,
+        "wing flaps geo (right)": 1200,
+        "body": 8000,
+        "wing (back left)": 3500,
+        "wing (back right)": 3500,
+        "engine l": 7500,
+        "fin left lower (tail)": 250,
+        "fin left upper (tail)": 250,
+        "engine r": 7500,
+        "fin right lower (tail)": 250,
+        "fin right upper (tail)": 250,
+        "arm (left)": 200,
+        "arm (right)": 200,
+        "nose": 31500
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          },
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s02_crossfield_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "AEGS_Vanguard_Sentinel": {
+      "name": "Vanguard Sentinel",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": 2012000,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1850000,
+        "speed": {
+          "max": 1075,
+          "scm": 210,
+          "roll": 126,
+          "pitch": 44,
+          "yaw": 39
+        },
+        "emission": {
+          "ir": 12534,
+          "em_idle": 16519,
+          "em_max": 44339
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 39
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_vanguard_scitem_turret"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "hrst_laserrepeater_s5"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        },
+        {
+          "size": 3,
+          "count": 4,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        },
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_em_taln_dominator"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "wing geo (left)": 800,
+        "wing geo (right)": 800,
+        "wing flaps geo (left)": 600,
+        "wing flaps geo (right)": 600,
+        "body": 10000,
+        "wing (back left)": 1800,
+        "wing (back right)": 1800,
+        "engine l": 10170,
+        "fin left lower (tail)": 250,
+        "fin left upper (tail)": 250,
+        "engine r": 10170,
+        "fin right lower (tail)": 250,
+        "fin right upper (tail)": 250,
+        "arm (left)": 200,
+        "arm (right)": 200,
+        "nose": 10000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_asas_s02_sheut_scitem"
+          },
+          {
+            "class": "shld_asas_s02_sheut_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_tydt_s02_gammamax_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_tydt_s02_heatsink_scitem"
+          },
+          {
+            "class": "cool_tydt_s02_heatsink_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_raco_s02_nova_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville"
+      ]
+    },
+    "AEGS_Vanguard": {
+      "name": "Vanguard Warden",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": 3387800,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 1850000,
+        "speed": {
+          "max": 1075,
+          "scm": 210,
+          "roll": 124,
+          "pitch": 44,
+          "yaw": 38
+        },
+        "emission": {
+          "ir": 11934,
+          "em_idle": 14139,
+          "em_max": 42233
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 40.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Player Controlled Turret",
+          "class": "aegs_vanguard_scitem_turret"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "espr_ballisticcannon_s5"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_ir_fski_ignite"
+        },
+        {
+          "size": 3,
+          "count": 4,
+          "missle-class": "misl_s03_cs_fski_arrester"
+        },
+        {
+          "size": 2,
+          "count": 4,
+          "missle-class": "misl_s02_em_taln_dominator"
+        }
+      ],
+      "defensive": [],
+      "health": {
+        "wing geo (left)": 800,
+        "wing geo (right)": 800,
+        "wing flaps geo (left)": 600,
+        "wing flaps geo (right)": 600,
+        "body": 10000,
+        "wing (back left)": 1800,
+        "wing (back right)": 1800,
+        "engine l": 7500,
+        "fin left lower (tail)": 250,
+        "fin left upper (tail)": 250,
+        "engine r": 7500,
+        "fin right lower (tail)": 250,
+        "fin right upper (tail)": 250,
+        "arm (left)": 200,
+        "arm (right)": 200,
+        "nose": 10000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          },
+          {
+            "class": "shld_godi_s02_fullstop_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_aegs_s02_maelstrom_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          },
+          {
+            "class": "cool_aegs_s02_arctic_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_wetk_s02_crossfield_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": [
+        "New Deal, Lorville",
+        "Vantage Rentals, Lorville"
+      ]
+    },
+    "DRAK_Vulture": {
+      "name": "Vulture",
+      "stats": {
+        "ship-size": "small",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 12,
+        "stowage": 1140000,
+        "speed": {
+          "max": 1100,
+          "scm": 200,
+          "roll": 125,
+          "pitch": 55,
+          "yaw": 55
+        },
+        "emission": {
+          "ir": 8951,
+          "em_idle": 7248,
+          "em_max": 26042
+        },
+        "fuel": {
+          "quantum": 1.1,
+          "hydro": 36
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "klwe_laserrepeater_s1"
+        }
+      ],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "nacelle left (front)": 5000,
+        "debrisproxy salvage arm (left)": 4000,
+        "nacelle right (front)": 5000,
+        "debrisproxy salvage arm (right)": 4000,
+        "tail": 2400,
+        "main engine (right)": 2000,
+        "main engine (left)": 2000,
+        "body": 12000,
+        "drone": 200,
+        "drone wing (right)": 50,
+        "drone wing (left)": 50,
+        "body (tail)": 7000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          },
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          },
+          {
+            "class": "shld_basl_s01_bulwark_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s01_fortitude_scitem"
+          },
+          {
+            "class": "powr_just_s01_fortitude_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s01_thermax_scitem"
+          },
+          {
+            "class": "cool_just_s01_thermax_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_just_s01_goliath_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ORIG_X1": {
+      "name": "X1",
+      "stats": {
+        "ship-size": "snub",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 350000,
+        "speed": {
+          "max": 569,
+          "scm": 207,
+          "roll": 135,
+          "pitch": 80,
+          "yaw": 80
+        },
+        "emission": {
+          "ir": 2020,
+          "em_idle": 1461,
+          "em_max": 13243
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0.9
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "tail": 340,
+        "wing right (tail)": 200,
+        "wing right break (tail)": 50,
+        "component door right (tail)": 50,
+        "component door right break (tail)": 50,
+        "wing left (tail)": 200,
+        "wing left break (tail)": 50,
+        "wing left cap (tail)": 50,
+        "component door left (tail)": 50,
+        "component door left break (tail)": 50,
+        "glass (rear)": 50,
+        "nose": 450,
+        "door nose (left)": 50,
+        "foot glass (left top)": 50,
+        "door nose (right)": 50,
+        "door body inner (right)": 50,
+        "foot glass (right top)": 50,
+        "body": 530,
+        "door body leg (top right)": 50,
+        "door body leg (bottom right)": 50,
+        "door body (right top)": 50,
+        "door body (right bottom)": 50,
+        "door body leg (top left)": 50,
+        "door body leg (bottom left)": 50,
+        "door body (left top)": 50,
+        "door body (left bottom)": 50,
+        "door body (top)": 50
+      },
+      "components": {
+        "shields": [],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_wcpr_s00_fridan_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ORIG_X1_Force": {
+      "name": "X1 Force",
+      "stats": {
+        "ship-size": "snub",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 350000,
+        "speed": {
+          "max": 569,
+          "scm": 207,
+          "roll": 135,
+          "pitch": 80,
+          "yaw": 80
+        },
+        "emission": {
+          "ir": 2000,
+          "em_idle": 1425,
+          "em_max": 13649
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0.9
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "tail": 340,
+        "wing right (tail)": 200,
+        "wing right break (tail)": 50,
+        "component door right (tail)": 50,
+        "component door right break (tail)": 50,
+        "wing left (tail)": 200,
+        "wing left break (tail)": 50,
+        "wing left cap (tail)": 50,
+        "component door left (tail)": 50,
+        "component door left break (tail)": 50,
+        "glass (rear)": 50,
+        "nose": 450,
+        "door nose (left)": 50,
+        "foot glass (left top)": 50,
+        "door nose (right)": 50,
+        "door body inner (right)": 50,
+        "foot glass (right top)": 50,
+        "body": 530,
+        "door body leg (top right)": 50,
+        "door body leg (bottom right)": 50,
+        "door body (right top)": 50,
+        "door body (right bottom)": 50,
+        "door body leg (top left)": 50,
+        "door body leg (bottom left)": 50,
+        "door body (left top)": 50,
+        "door body (left bottom)": 50,
+        "door body (top)": 50
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_seco_s00_pin_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_wcpr_s00_fridan_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "ORIG_X1_Velocity": {
+      "name": "X1 Velocity",
+      "stats": {
+        "ship-size": "snub",
+        "purchase-price": null,
+        "crew": 1,
+        "cargo": 0,
+        "stowage": 350000,
+        "speed": {
+          "max": 611,
+          "scm": 222,
+          "roll": 140,
+          "pitch": 93,
+          "yaw": 93
+        },
+        "emission": {
+          "ir": 1985,
+          "em_idle": 1406,
+          "em_max": 13188
+        },
+        "fuel": {
+          "quantum": 0,
+          "hydro": 0.9
+        }
+      },
+      "weapons": [],
+      "missles": [],
+      "defensive": [],
+      "health": {
+        "tail": 340,
+        "wing right (tail)": 200,
+        "wing right break (tail)": 50,
+        "component door right (tail)": 50,
+        "component door right break (tail)": 50,
+        "wing left (tail)": 200,
+        "wing left break (tail)": 50,
+        "wing left cap (tail)": 50,
+        "component door left (tail)": 50,
+        "component door left break (tail)": 50,
+        "glass (rear)": 50,
+        "nose": 450,
+        "door nose (left)": 50,
+        "foot glass (left top)": 50,
+        "door nose (right)": 50,
+        "door body inner (right)": 50,
+        "foot glass (right top)": 50,
+        "body": 530,
+        "door body leg (top right)": 50,
+        "door body leg (bottom right)": 50,
+        "door body (right top)": 50,
+        "door body (right bottom)": 50,
+        "door body leg (top left)": 50,
+        "door body leg (bottom left)": 50,
+        "door body (left top)": 50,
+        "door body (left bottom)": 50,
+        "door body (top)": 50
+      },
+      "components": {
+        "shields": [],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s00_radix_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_wcpr_s00_fridan_scitem"
+          }
+        ],
+        "quantum-drives": []
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "RSI_Zeus_CL": {
+      "name": "Zeus Mk II CL",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": null,
+        "crew": 3,
+        "cargo": 128,
+        "stowage": 3680000,
+        "speed": {
+          "max": 1000,
+          "scm": 200,
+          "roll": 105,
+          "pitch": 34,
+          "yaw": 30
+        },
+        "emission": {
+          "ir": 14071,
+          "em_idle": 10069,
+          "em_max": 46509
+        },
+        "fuel": {
+          "quantum": 1.8,
+          "hydro": 66.5
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s4"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 8,
+          "missle-class": "misl_s02_em_taln_dominator"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "noise",
+          "count": 10,
+          "name": "Joker Defcon - Noise Launcher"
+        },
+        {
+          "type": "decoy",
+          "count": 25,
+          "name": "Joker Defcon Flares Ammo"
+        }
+      ],
+      "health": {
+        "body": 15000,
+        "bar debris (right)": 800,
+        "wing debris (bottom right)": 1200,
+        "wing debris (bottom left)": 1200,
+        "wing debris (top right)": 2000,
+        "wing debris (top left)": 2000,
+        "bar debris (left)": 800,
+        "nose": 9000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_basl_s02_aspis_scitem"
+          },
+          {
+            "class": "shld_basl_s02_aspis_scitem"
+          },
+          {
+            "class": "shld_basl_s02_aspis_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_just_s02_diligence_scitem"
+          },
+          {
+            "class": "powr_just_s02_diligence_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_just_s02_coolcore_scitem"
+          },
+          {
+            "class": "cool_just_s02_coolcore_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s02_khaos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    },
+    "RSI_Zeus_ES": {
+      "name": "Zeus Mk II ES",
+      "stats": {
+        "ship-size": "medium",
+        "purchase-price": null,
+        "crew": 3,
+        "cargo": 32,
+        "stowage": 3810000,
+        "speed": {
+          "max": 1100,
+          "scm": 205,
+          "roll": 110,
+          "pitch": 32.5,
+          "yaw": 32.5
+        },
+        "emission": {
+          "ir": 14107,
+          "em_idle": 12348,
+          "em_max": 38008
+        },
+        "fuel": {
+          "quantum": 2.6,
+          "hydro": 93.1
+        }
+      },
+      "weapons": [
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s4"
+        },
+        {
+          "type": "Pilot Controlled",
+          "class": "amrs_lasercannon_s4"
+        }
+      ],
+      "missles": [
+        {
+          "size": 2,
+          "count": 8,
+          "missle-class": "misl_s02_em_taln_dominator"
+        }
+      ],
+      "defensive": [
+        {
+          "type": "noise",
+          "count": 10,
+          "name": "Joker Defcon - Noise Launcher"
+        },
+        {
+          "type": "decoy",
+          "count": 25,
+          "name": "Joker Defcon Flares Ammo"
+        }
+      ],
+      "health": {
+        "body": 15000,
+        "bar debris (right)": 800,
+        "wing debris (bottom right)": 1200,
+        "wing debris (bottom left)": 1200,
+        "wing debris (top right)": 2000,
+        "wing debris (top left)": 2000,
+        "bar debris (left)": 800,
+        "nose": 9000
+      },
+      "components": {
+        "shields": [
+          {
+            "class": "shld_behr_s02_5ma_scitem"
+          },
+          {
+            "class": "shld_behr_s02_5ma_scitem"
+          },
+          {
+            "class": "shld_behr_s02_5ma_scitem"
+          },
+          {
+            "class": "shld_behr_s02_5ma_scitem"
+          }
+        ],
+        "power-plants": [
+          {
+            "class": "powr_lplt_s02_fullforce_scitem"
+          },
+          {
+            "class": "powr_lplt_s02_fullforce_scitem"
+          }
+        ],
+        "coolers": [
+          {
+            "class": "cool_lplt_s02_coldsnap_scitem"
+          },
+          {
+            "class": "cool_lplt_s02_coldsnap_scitem"
+          }
+        ],
+        "quantum-drives": [
+          {
+            "class": "qdrv_rsi_s02_khaos_scitem"
+          }
+        ]
+      },
+      "flight-ready": false,
+      "shops": []
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "statizen",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "statizen",
-      "version": "1.0.3",
+      "version": "1.0.5",
       "dependencies": {
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-select": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "statizen",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3596,7 +3596,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "statizen"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "log",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "statizen"
-version = "1.0.4"
+version = "1.0.5"
 description = "Statizen"
 authors = ["Chris Narowski"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,8 +29,6 @@
     "active": true,
     "targets": "all",
     "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"],
-    "resources": {
-      "exclude": ["db-builder/**/*"]
-    }
+    "resources": []
   }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "statizen",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "identifier": "com.statizen.app",
   "build": {
     "frontendDist": "../dist",
@@ -28,6 +28,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"]
+    "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns", "icons/icon.ico"],
+    "resources": {
+      "exclude": ["db-builder/**/*"]
+    }
   }
 }

--- a/src/assets/NPC-Dictionary.json
+++ b/src/assets/NPC-Dictionary.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.0.5",
   "dictionary": {
     "Kopion_Irradiated": {
       "name": "Kopion (Irradiated)"

--- a/src/assets/Ship-Dictionary.json
+++ b/src/assets/Ship-Dictionary.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.0.5",
   "dictionary": {
     "template": {
       "name": "",

--- a/src/assets/Weapon-Dictionary.json
+++ b/src/assets/Weapon-Dictionary.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.5",
   "dictionary": {
     "template": {
       "name": "",

--- a/src/assets/new-ship-dictionary.json
+++ b/src/assets/new-ship-dictionary.json
@@ -1,0 +1,37 @@
+{
+  "live": {
+    "ORIG_100i": {
+      "name": "100i",
+      "weapons": [],
+      "components": {
+        "engines": [],
+        "shields": [],
+        "power-plants": [],
+        "coolers": [],
+        "quantum-drives": [],
+        "thrusters": []
+      },
+      "stats": {
+        "ship-size": ""
+      },
+      "missles": [],
+      "image": "400px-100i_Microtech_-_cropped.png.webp",
+      "role": "Starter / Pathfinder",
+      "size": "S1/XXS",
+      "crew": 1,
+      "base-dps": 1091,
+      "HullBody": 1650,
+      "cargo": 2,
+      "shield-type": "WEB",
+      "shield-capacity": 1500,
+      "pilot-guns": "2 x S3",
+      "turret-guns": "",
+      "missles": "2 x S2",
+      "manufacturer": "Origin Jumpworks",
+      "manufacturer-code": "ORIG",
+      "verified": true,
+      "versus-wins": 0,
+      "versus-losses": 0
+    }
+  }
+}

--- a/src/lib/discord/discordUtil.js
+++ b/src/lib/discord/discordUtil.js
@@ -71,23 +71,15 @@ const getXPProgressBar = (xp) => {
 
 const sendDiscordWebhook = async (webhookUrl, embed) => {
   try {
-    console.log('📡 Sending Discord webhook to:', webhookUrl);
-    console.log('📦 Embed data:', JSON.stringify(embed, null, 2));
-
     const response = await fetch(webhookUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ embeds: [embed] }),
     });
 
-    console.log('📡 Discord webhook response status:', response.status);
-    console.log('📡 Discord webhook response ok:', response.ok);
-
     if (!response.ok) {
       const errorText = await response.text();
       console.error('❌ Discord webhook failed:', errorText);
-    } else {
-      console.log('✅ Discord webhook sent successfully');
     }
 
     return response.ok;
@@ -234,13 +226,8 @@ export const reportPVPKill = async (victimName, victimShipClass, currentShipClas
 
 export const reportPVEKill = async (npcClass, currentShipClass, weaponClass = null, killedShipClass = null) => {
   const settings = await loadSettings();
-  console.log('⚙️ Discord settings:', {
-    discordEnabled: settings.discordEnabled,
-    hasWebhookUrl: !!settings.discordWebhookUrl,
-    pveKillsEnabled: settings.eventTypes?.pveKills
-  });
+
   if (!settings.discordEnabled || !settings.discordWebhookUrl || !settings.eventTypes?.pveKills) {
-    console.log('❌ Discord PVE kill report skipped - settings not enabled');
     return false;
   }
 

--- a/src/lib/handleOpenFile.js
+++ b/src/lib/handleOpenFile.js
@@ -12,7 +12,6 @@ export async function handleOpenFile() {
   });
 
   if (selectedPath) {
-    console.log('Selected file:', selectedPath);
     return selectedPath;
   }
 }

--- a/src/lib/hooks/useVersionCheck.js
+++ b/src/lib/hooks/useVersionCheck.js
@@ -3,37 +3,36 @@ import { useState, useEffect } from 'react';
 import { checkForUpdates } from '@/lib/utils/versionCheck';
 
 export const useVersionCheck = () => {
-    const [updateInfo, setUpdateInfo] = useState({
-        hasUpdate: false,
-        currentVersion: __APP_VERSION__ || '1.0.1',
-        latestVersion: null,
-        loading: false
-    });
+  const [updateInfo, setUpdateInfo] = useState({
+    hasUpdate: false,
+    currentVersion: __APP_VERSION__ || '1.0.1',
+    latestVersion: null,
+    loading: false,
+  });
 
-    useEffect(() => {
-        const checkUpdates = async () => {
-            try {
-                setUpdateInfo(prev => ({ ...prev, loading: true }));
-                const result = await checkForUpdates();
-                setUpdateInfo({
-                    ...result,
-                    loading: false
-                });
-            } catch (error) {
-                console.log('Version check error:', error);
-                setUpdateInfo({
-                    hasUpdate: false,
-                    currentVersion: __APP_VERSION__ || '1.0.1',
-                    latestVersion: null,
-                    loading: false
-                });
-            }
-        };
+  useEffect(() => {
+    const checkUpdates = async () => {
+      try {
+        setUpdateInfo((prev) => ({ ...prev, loading: true }));
+        const result = await checkForUpdates();
+        setUpdateInfo({
+          ...result,
+          loading: false,
+        });
+      } catch (error) {
+        setUpdateInfo({
+          hasUpdate: false,
+          currentVersion: __APP_VERSION__ || '1.0.1',
+          latestVersion: null,
+          loading: false,
+        });
+      }
+    };
 
-        // Check for updates after a short delay
-        const timer = setTimeout(checkUpdates, 2000);
-        return () => clearTimeout(timer);
-    }, []);
+    // Check for updates after a short delay
+    const timer = setTimeout(checkUpdates, 2000);
+    return () => clearTimeout(timer);
+  }, []);
 
-    return updateInfo;
-}; 
+  return updateInfo;
+};

--- a/src/lib/initialization/processNameandID.js
+++ b/src/lib/initialization/processNameandID.js
@@ -1,39 +1,28 @@
 import { loadUser, saveUser } from '@/lib/user/userUtil';
 
 export const extractUserData = (line) => {
-  console.log('🔍 Extracting user data from line:', line);
   const updates = {};
 
   // Extract name (userName) - looks for "name [value]" after a dash
   const nameMatch = line.match(/(?<=-\sname\s)[^]+?(?=\s-)/);
   if (nameMatch) {
     updates.userName = nameMatch[0].trim();
-    console.log('✅ Found userName:', updates.userName);
-  } else {
-    console.log('❌ No userName match found');
   }
 
   // Extract geid - looks for "geid [value]" after a dash
   const geidMatch = line.match(/(?<=-\sgeid\s)\d+(?=\s-)/);
   if (geidMatch) {
     updates.geid = geidMatch[0];
-    console.log('✅ Found geid:', updates.geid);
-  } else {
-    console.log('❌ No geid match found');
   }
 
-  console.log('📝 Extracted updates:', updates);
   return updates;
 };
 
 export const processNameAndID = async (line) => {
-  console.log('🚀 processNameAndID called with line:', line);
-
   // Extract user data from the line
   const userUpdates = extractUserData(line);
 
   if (Object.keys(userUpdates).length > 0) {
-    console.log('💾 Saving user updates:', userUpdates);
     // Load existing user data
     const existingUserData = await loadUser();
 
@@ -42,11 +31,8 @@ export const processNameAndID = async (line) => {
 
     // Save updated user data
     await saveUser(updatedUserData);
-    console.log('✅ User data saved successfully');
 
     return updatedUserData;
-  } else {
-    console.log('⚠️ No user updates found, line may not contain expected format');
   }
 
   return null;
@@ -59,7 +45,5 @@ export const processStarCitizenVersion = async (line) => {
     const updates = { starCitizenVersion: starCitizenVersion[0] };
     const updatedUserData = { ...existingUserData, ...updates };
     await saveUser(updatedUserData);
-  } else {
-    console.log('No star citizen version found in log file');
   }
 };

--- a/src/lib/pvp/pvpUtil.js
+++ b/src/lib/pvp/pvpUtil.js
@@ -102,7 +102,10 @@ export async function checkMonthChange() {
     };
     // Preserve XP across months
     if (!pvp.xp) pvp.xp = 0;
-    await savePVP(pvp);
+
+    // Write directly to file instead of calling savePVP() to avoid infinite recursion
+    const path = await getPVPPath();
+    await writeTextFile(path, JSON.stringify(pvp, null, 2));
   }
 }
 

--- a/src/processing_engine/rules/crashEvent.js
+++ b/src/processing_engine/rules/crashEvent.js
@@ -8,34 +8,34 @@ const consoleDebugging = false;
 
 export async function crashEvent(line) {
   consoleDebugging && console.log('🔍 Processing crashEvent line:', line);
-  
+
   try {
     let userData = await loadUser();
     const userName = userData.userName;
     const pveData = await loadPVE();
-    
+
     consoleDebugging && console.log('👤 Current user:', userName);
 
     // === Fatal Collision Detection ===
     if (line.includes('<FatalCollision>')) {
       consoleDebugging && console.log('💥 FATAL COLLISION DETECTED!');
-      
+
       // Extract vehicle information
       const vehicleMatch = line.match(/vehicle ([^\s]+)/);
       const vehicleName = vehicleMatch ? vehicleMatch[1] : 'Unknown Vehicle';
-      
+
       consoleDebugging && console.log('🚗 Vehicle involved:', vehicleName);
-      
+
       // Log the crash event
       addPVELogEntry('crash', 'loss', vehicleName);
-      
+
       await queueKDUpdate(async () => {
         const updatedPVE = { ...pveData };
         updatedPVE.deaths += 1;
         updatedPVE.currentMonth.deaths += 1;
         await savePVE(updatedPVE);
       });
-      
+
       // Send Discord notification for crash
       await reportCrash(vehicleName);
       return;
@@ -44,35 +44,37 @@ export async function crashEvent(line) {
     // === Vehicle Destruction Detection ===
     if (line.includes('<Vehicle Destruction>')) {
       consoleDebugging && console.log('💥 VEHICLE DESTRUCTION DETECTED!');
-      
-      // Extract vehicle information
-      const vehicleMatch = line.match(/Vehicle '([^']+)'/);
-      const vehicleName = vehicleMatch ? vehicleMatch[1] : 'Unknown Vehicle';
-      
-      consoleDebugging && console.log('🚗 Vehicle destroyed:', vehicleName);
-      
-      // Extract cause information
-      const causeMatch = line.match(/caused by '([^']+)'/);
-      const cause = causeMatch ? causeMatch[1] : 'Unknown';
-      
-      consoleDebugging && console.log('🔍 Destruction cause:', cause);
-      
-      // Only log if it was caused by the current user
-      if (cause === userName) {
-        consoleDebugging && console.log('✅ Vehicle destruction caused by current user');
-        
-        // Log the vehicle destruction event
-        addPVELogEntry('vehicle_destruction', 'loss', vehicleName);
-        
-        // Note: We don't increment death count here since it's already handled by the Actor Death event
-        // This is just for tracking vehicle destruction separately
+
+      try {
+        // Extract vehicle information - more robust regex to handle complex vehicle names
+        const vehicleMatch = line.match(/Vehicle '([^']+)'/);
+        const vehicleName = vehicleMatch ? vehicleMatch[1] : 'Unknown Vehicle';
+
+        consoleDebugging && console.log('🚗 Vehicle destroyed:', vehicleName);
+
+        // Extract cause information - more robust regex to handle complex player names
+        const causeMatch = line.match(/caused by '([^']+)'/);
+        const cause = causeMatch ? causeMatch[1] : 'Unknown';
+
+        consoleDebugging && console.log('🔍 Destruction cause:', cause);
+
+        // Only log if it was caused by the current user
+        if (cause === userName) {
+          consoleDebugging && console.log('✅ Vehicle destruction caused by current user');
+
+          // Log the vehicle destruction event
+          addPVELogEntry('vehicle_destruction', 'loss', vehicleName);
+        }
+      } catch (parseError) {
+        console.error('Error parsing vehicle destruction line:', parseError);
+        console.error('Problematic line:', line);
+        // Continue processing instead of crashing
       }
-      
+
       return;
     }
-
   } catch (error) {
     console.error('Error processing crash event:', error);
     return null;
   }
-} 
+}

--- a/src/views/Dashboard.jsx
+++ b/src/views/Dashboard.jsx
@@ -224,7 +224,7 @@ function Dashboard() {
       {/* System Information */}
       <Card className='flex-shrink-0'>
         <CardContent>
-          <div className='grid grid-cols-2 gap-4 max-w-2xl mx-auto'>
+          <div className='grid grid-cols-2 gap-4 mx-auto'>
             <div className='flex items-center gap-3 p-3 border rounded-lg'>
               <Gamepad2 className='w-5 h-5 text-blue-600' />
               <div>


### PR DESCRIPTION
# Pull Request

## What's this change?

Found an issue with the PVP tracker where at the change of the month it went into a recursive state to try and reset the month's pvp stats.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] ⚡ Performance improvement
- [ ] 🔧 Refactoring (no functional changes)
- [ ] 🧪 Test addition or improvement

## Changes Made

- Removed recursive flow, changed PVP month changes to save file in a separate state as the pvp save does a month check
- This has some dictionary updates as well where we are working to have an auto-update dictionary
